### PR TITLE
Add ability to add custom columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ vis: {
     labelPartition: false,
     labelCheckbox: false,
     labelIdentity: 'Ident',
+    customColumnsGetter: columnGetterFunc // this is a custom function which will return information (cell, width, header) of custom columns, it will take index of the column as an arguement and will of the following signature: (index: number) => {width: number, cell: function || string || DOMElement}
+    customColumnsCount: 3 //number of custom columns
 
     // meta stuff
     metaGaps: true,

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ vis: {
     labelPartition: false,
     labelCheckbox: false,
     labelIdentity: 'Ident',
-    customColumnsGetter: columnGetterFunc // this is a custom function which will return information (cell, width, header) of custom columns, it will take index of the column as an arguement and will of the following signature: (index: number) => {width: number, cell: function || string || DOMElement}
+    customColumnsGetter: columnGetterFunc // this is a custom function which will return information (cell, width, header) of custom columns, it will take index of the column as an arguement and will of the following signature: (index: number) => {width: number, cell: function || string || DOMElement, header: function || string || DOMElement}
     customColumnsCount: 3 //number of custom columns
 
     // meta stuff

--- a/README.md
+++ b/README.md
@@ -408,8 +408,20 @@ vis: {
     labelPartition: false,
     labelCheckbox: false,
     labelIdentity: 'Ident',
-    customColumnsGetter: columnGetterFunc // this is a custom function which will return information (cell, width, header) of custom columns, it will take index of the column as an arguement and will of the following signature: (index: number) => {width: number, cell: function || string || DOMElement, header: function || string || DOMElement}
-    customColumnsCount: 3 //number of custom columns
+    /*
+    this can be overridden with a custom function of the following signature:
+        (index: number) => ColumnInfo
+      where ColumnInfo represents the details about a column:
+        {
+          width: number, 
+          header: (function | string | DOMElement),
+          cell: (function | string | DOMElement),
+        }
+      `header` or `cell` can also be a function of the following signature:
+        (seqId: string) => (string | DOMElement)
+    */
+    customColumnsGetter: undefined,
+    customColumnsCount: 0, // number of custom columns
 
     // meta stuff
     metaGaps: true,

--- a/snippets/custom_columns.js
+++ b/snippets/custom_columns.js
@@ -5,8 +5,8 @@ yourDiv.textContent = "loading";
 var opts = {};
 opts.el = yourDiv;
 
-const customValueCalculator = (attr) => {
-  return attr.id + attr.seq[0];
+const customValueCalculator = (id) => {
+  return id + " custom";
 }
 
 const getDomElement = (text, width) => {
@@ -17,8 +17,8 @@ const getDomElement = (text, width) => {
   domEl.style.display = "inline-block";
   return domEl;
 }
-const customDomCalculator = (attr) => {
-  const domEl = getDomElement(attr.id+attr.name, 90)
+const customDomCalculator = (id) => {
+  const domEl = getDomElement("seq " + id, 90)
   domEl.style.backgroundColor = "red";
   return domEl;
 }
@@ -26,7 +26,7 @@ const customDomCalculator = (attr) => {
 const customColumns = [
   {
     header: 'Custom 1',
-    length: 50,
+    length: 90,
     cell: customValueCalculator,
   }, 
   {
@@ -73,12 +73,6 @@ m.render();
 renderMSA(msa.utils.seqgen.getDummySequences(20,20));
 
 function renderMSA(seqs) {
-  // hide some UI elements for large alignments
-  if (seqs.length > 1000) {
-    m.g.vis.set("conserv", false);
-    m.g.vis.set("metacell", false);
-    m.g.vis.set("overviewbox", false);
-  }
   m.seqs.reset(seqs);
   m.g.zoomer.set("alignmentWidth", "auto");
   m.render();

--- a/snippets/custom_columns.js
+++ b/snippets/custom_columns.js
@@ -5,8 +5,8 @@ yourDiv.textContent = "loading";
 var opts = {};
 opts.el = yourDiv;
 
-const customValueCalculator = (id, seq) => {
-  return id + seq[0];
+const customValueCalculator = (attr) => {
+  return attr.id + attr.seq[0];
 }
 
 const getDomElement = (text, width) => {
@@ -17,8 +17,8 @@ const getDomElement = (text, width) => {
   domEl.style.display = "inline-block";
   return domEl;
 }
-const customDomCalculator = (id, seq) => {
-  const domEl = getDomElement(id+seq.length, 90)
+const customDomCalculator = (attr) => {
+  const domEl = getDomElement(attr.id+attr.name, 90)
   domEl.style.backgroundColor = "red";
   return domEl;
 }

--- a/snippets/custom_columns.js
+++ b/snippets/custom_columns.js
@@ -1,0 +1,85 @@
+var msa = window.msa;
+
+yourDiv.textContent = "loading";
+
+var opts = {};
+opts.el = yourDiv;
+
+const customValueCalculator = (id, seq) => {
+  return id + seq[0];
+}
+
+const getDomElement = (text, width) => {
+  const domEl = document.createElement("span")
+  domEl.classList.add("custom-column");
+  domEl.textContent = text;
+  domEl.style.width = width + "px";
+  domEl.style.display = "inline-block";
+  return domEl;
+}
+const customDomCalculator = (id, seq) => {
+  const domEl = getDomElement(id+seq.length, 90)
+  domEl.style.backgroundColor = "red";
+  return domEl;
+}
+
+const customColumns = [
+  {
+    header: 'Custom 1',
+    length: 50,
+    cell: customValueCalculator,
+  }, 
+  {
+    header: getDomElement("Custom 2", 120),
+    length: 120,
+    cell: 50,
+  },
+  {
+    header: 'Custom 3',
+    length: 90,
+    cell: customDomCalculator,
+  }
+]
+
+const customColumnCalculator = (idx) => {
+  return customColumns[idx];
+};
+
+opts.vis = {
+  conserv: false,
+  overviewbox: false,
+  customColumnsGetter: customColumnCalculator,
+  customColumnsCount: 3,
+  labelName: false,
+};
+opts.zoomer = {
+  boxRectHeight: 1,
+  boxRectWidth: 1,
+  alignmentHeight: window.innerHeight * 0.8,
+  labelFontsize: 12,
+  labelIdLength: 50,
+};
+var m = msa(opts);
+
+// the menu is independent to the MSA container
+var menuOpts = {};
+menuOpts.msa = m;
+var defMenu = new msa.menu.defaultmenu(menuOpts);
+m.addView("menu", defMenu);
+
+m.seqs.reset(msa.utils.seqgen.getDummySequences(20, 20));
+m.g.zoomer.set("alignmentWidth", "auto");
+m.render();
+renderMSA(msa.utils.seqgen.getDummySequences(20,20));
+
+function renderMSA(seqs) {
+  // hide some UI elements for large alignments
+  if (seqs.length > 1000) {
+    m.g.vis.set("conserv", false);
+    m.g.vis.set("metacell", false);
+    m.g.vis.set("overviewbox", false);
+  }
+  m.seqs.reset(seqs);
+  m.g.zoomer.set("alignmentWidth", "auto");
+  m.render();
+}

--- a/snippets/large_set.js
+++ b/snippets/large_set.js
@@ -4,25 +4,16 @@ yourDiv.textContent = "loading";
 
 var opts = {};
 opts.el = yourDiv;
-
-const customValueCalculator = (id, currentSequence) => {
-  return Math.random() * 100;
-};
-
 opts.vis = {
   conserv: false,
-  overviewbox: false,
-  labelCustomColumnsNames: ['homoscore'],
-  labelCustomColumnsValuesGetter: [customValueCalculator],
-  labelCustomColumns: true,
+  overviewbox: false
 };
 opts.zoomer = {
   boxRectHeight: 1,
   boxRectWidth: 1,
   alignmentHeight: window.innerHeight * 0.8,
   labelFontsize: 12,
-  labelIdLength: 50,
-  labelCustomColumnLengths: [120],
+  labelIdLength: 50
 };
 var m = msa(opts);
 

--- a/snippets/large_set.js
+++ b/snippets/large_set.js
@@ -4,16 +4,25 @@ yourDiv.textContent = "loading";
 
 var opts = {};
 opts.el = yourDiv;
+
+const customValueCalculator = (id, currentSequence) => {
+  return Math.random() * 100;
+};
+
 opts.vis = {
   conserv: false,
-  overviewbox: false
+  overviewbox: false,
+  labelCustomColumnsNames: ['homoscore'],
+  labelCustomColumnsValuesGetter: [customValueCalculator],
+  labelCustomColumns: true,
 };
 opts.zoomer = {
   boxRectHeight: 1,
   boxRectWidth: 1,
   alignmentHeight: window.innerHeight * 0.8,
   labelFontsize: 12,
-  labelIdLength: 50
+  labelIdLength: 50,
+  labelCustomColumnLengths: [120],
 };
 var m = msa(opts);
 

--- a/src/g/visibility.js
+++ b/src/g/visibility.js
@@ -21,7 +21,7 @@ module.exports = Visibility = Model.extend({
     labelIdentity: 'Ident',
     labelPartition: false,
     labelCheckbox: false,
-    labelCustomColumns: false,
+    customColumnsCount: 0,
 
     // meta stuff
     metaGaps: true,

--- a/src/g/visibility.js
+++ b/src/g/visibility.js
@@ -21,6 +21,7 @@ module.exports = Visibility = Model.extend({
     labelIdentity: 'Ident',
     labelPartition: false,
     labelCheckbox: false,
+    labelCustomColumns: false,
 
     // meta stuff
     metaGaps: true,
@@ -40,7 +41,7 @@ module.exports = Visibility = Model.extend({
     }), this
     );
 
-    this.listenTo( this, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:labelIdentity", (function() {
+    this.listenTo( this, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:labelIdentity change:labelCustomColumns", (function() {
       return this.trigger("change:labels");
     }), this
     );

--- a/src/g/visibility.js
+++ b/src/g/visibility.js
@@ -41,7 +41,7 @@ module.exports = Visibility = Model.extend({
     }), this
     );
 
-    this.listenTo( this, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:labelIdentity change:labelCustomColumns", (function() {
+    this.listenTo( this, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:labelIdentity change:customColumnsGetter change:customColumnsCount", (function() {
       return this.trigger("change:labels");
     }), this
     );

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -9,7 +9,7 @@ module.exports = Zoomer = Model.extend({
     this.g = options.g;
 
     // events
-    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength change:labelCustomColumnLengths change:labelCustomValueDefaultLength", (function() {
+    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength change:customColumnsGetter change:customColumnsCount", (function() {
       return this.trigger("change:labelWidth", this.getLabelWidth());
     }), this
     );
@@ -129,12 +129,9 @@ module.exports = Zoomer = Model.extend({
      var val = 0;
      if (this.g.vis.get("labelName")) { val += this.get("labelNameLength"); }
      if (this.g.vis.get("labelId")) { val += this.get("labelIdLength"); }
-     if (this.g.vis.get("labelCustomColumns")) {
-        if (this.get("labelCustomColumnLengths")) {
-          this.get("labelCustomColumnLengths").forEach((width)=> val += width);
-        }
-        else {
-          val += this.get("labelCustomValueDefaultLength") * this.g.vis.get("labelCustomColumnsValuesGetter").length;
+     if (this.g.vis.get("customColumnsGetter")) {
+        for (var idx = 0 ; idx < this.g.vis.get("customColumnsCount") ; idx++) {
+          val += this.g.vis.get("customColumnsGetter")(idx).length || 50;
         }
      }
      if (this.g.vis.get("labelPartition")) { val += this.get("labelPartLength"); }

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -9,7 +9,7 @@ module.exports = Zoomer = Model.extend({
     this.g = options.g;
 
     // events
-    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength change:customColumnsGetter change:customColumnsCount", (function() {
+    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength change:customColumnsGetter change:customColumnsCount change:customColumnsDefaultLength", (function() {
       return this.trigger("change:labelWidth", this.getLabelWidth());
     }), this
     );
@@ -34,11 +34,11 @@ module.exports = Zoomer = Model.extend({
     labelIdLength: 20,
     labelIdentityLength: 25,
     labelNameLength: 100,
-    labelCustomValueDefaultLength: 50,
     labelPartLength: 15,
     labelCheckLength: 15,
     labelFontsize: 13,
     labelLineHeight: "13px",
+    customColumnsDefaultLength: 50,
 
     // marker
     markerFontsize: "10px",
@@ -131,7 +131,7 @@ module.exports = Zoomer = Model.extend({
      if (this.g.vis.get("labelId")) { val += this.get("labelIdLength"); }
      if (this.g.vis.get("customColumnsGetter")) {
         for (var idx = 0 ; idx < this.g.vis.get("customColumnsCount") ; idx++) {
-          val += this.g.vis.get("customColumnsGetter")(idx).length || 50;
+          val += this.g.vis.get("customColumnsGetter")(idx).length || this.get("customColumnsDefaultLength");
         }
      }
      if (this.g.vis.get("labelPartition")) { val += this.get("labelPartLength"); }

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -9,7 +9,7 @@ module.exports = Zoomer = Model.extend({
     this.g = options.g;
 
     // events
-    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength", (function() {
+    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength change:labelCustomColumnLengths change:labelCustomValueDefaultLength", (function() {
       return this.trigger("change:labelWidth", this.getLabelWidth());
     }), this
     );
@@ -34,6 +34,7 @@ module.exports = Zoomer = Model.extend({
     labelIdLength: 20,
     labelIdentityLength: 25,
     labelNameLength: 100,
+    labelCustomValueDefaultLength: 50,
     labelPartLength: 15,
     labelCheckLength: 15,
     labelFontsize: 13,
@@ -128,6 +129,14 @@ module.exports = Zoomer = Model.extend({
      var val = 0;
      if (this.g.vis.get("labelName")) { val += this.get("labelNameLength"); }
      if (this.g.vis.get("labelId")) { val += this.get("labelIdLength"); }
+     if (this.g.vis.get("labelCustomColumns")) {
+        if (this.get("labelCustomColumnLengths")) {
+          this.get("labelCustomColumnLengths").forEach((width)=> val += width);
+        }
+        else {
+          val += this.get("labelCustomValueDefaultLength") * this.g.vis.get("labelCustomColumnsValuesGetter").length;
+        }
+     }
      if (this.g.vis.get("labelPartition")) { val += this.get("labelPartLength"); }
      if (this.g.vis.get("labelCheckbox")) { val += this.get("labelCheckLength"); }
      return val;

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -9,7 +9,7 @@ const LabelHeader = view.extend({
   initialize: function(data) {
     this.g = data.g;
 
-    this.listenTo(this.g.vis, "change:metacell change:labels", this.render);
+    this.listenTo(this.g.vis, "change:metacell change:labels change: labelCustomColumnsNames", this.render);
     return this.listenTo(this.g.zoomer, "change:labelWidth change:metaWidth", this.render);
   },
 
@@ -55,6 +55,15 @@ const LabelHeader = view.extend({
       var name = this.addEl("Label");
       //name.style.marginLeft = "50px"
       labelHeader.appendChild(name);
+    }
+
+    if (this.g.vis.get("labelCustomColumns")) {
+      this.g.vis.get("labelCustomColumnsNames").forEach( (col, index) => {
+        const length = this.g.zoomer.get("labelCustomColumnLengths") ? this.g.zoomer.get("labelCustomColumnLengths")[index] : this.g.zoomer.get("labelCustomValueDefaultLength");
+        var labelCustom = this.addEl(col, length);
+
+        labelHeader.appendChild(labelCustom);
+      });
     }
 
     return labelHeader;

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -61,19 +61,16 @@ const LabelHeader = view.extend({
       for(var idx = 0; idx < this.g.vis.get("customColumnsCount"); idx++) {
         const column = this.g.vis.get("customColumnsGetter")(idx);
         const length = column.length || this.g.zoomer.get("customColumnsDefaultLength");
-        const header = column.header;
-        if ( header instanceof Element ) {
-          labelHeader.appendChild(header);
+        var header = column.header;
+        
+        if (typeof header === 'function') {
+          header = header();
+        }
+
+        if (!( header instanceof Element )) {
+          header = this.addEl(header, length);
         } 
-        else if (typeof header === 'function') {
-          const val = header();
-          const labelCustom = this.addEl(val, length);
-          labelHeader.appendChild(labelCustom);
-        }
-        else {
-          const labelCustom = this.addEl(header, length);
-          labelHeader.appendChild(labelCustom);
-        }
+        labelHeader.appendChild(header);
       }
     }
     return labelHeader;

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -52,7 +52,7 @@ const LabelHeader = view.extend({
     }
 
     if (this.g.vis.get("labelName")) {
-      var name = this.addEl("Label");
+      var name = this.addEl("Label", this.g.zoomer.get("labelNameLength"));
       //name.style.marginLeft = "50px"
       labelHeader.appendChild(name);
     }

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -60,9 +60,9 @@ const LabelHeader = view.extend({
     if (this.g.vis.get("customColumnsGetter")) {
       for(var idx = 0; idx < this.g.vis.get("customColumnsCount"); idx++) {
         const column = this.g.vis.get("customColumnsGetter")(idx);
-        const length = column.length || 50;
+        const length = column.length || this.g.zoomer.get("customColumnsDefaultLength");
         const header = column.header;
-        if ( header instanceof Element || header instanceof HTMLDocument ) {
+        if ( header instanceof Element ) {
           labelHeader.appendChild(header);
         } 
         else if (typeof header === 'function') {

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -9,7 +9,7 @@ const LabelHeader = view.extend({
   initialize: function(data) {
     this.g = data.g;
 
-    this.listenTo(this.g.vis, "change:metacell change:labels change: labelCustomColumnsNames", this.render);
+    this.listenTo(this.g.vis, "change:metacell change:labels change:customColumnsGetter change:customColumnsCount", this.render);
     return this.listenTo(this.g.zoomer, "change:labelWidth change:metaWidth", this.render);
   },
 
@@ -57,15 +57,25 @@ const LabelHeader = view.extend({
       labelHeader.appendChild(name);
     }
 
-    if (this.g.vis.get("labelCustomColumns")) {
-      this.g.vis.get("labelCustomColumnsNames").forEach( (col, index) => {
-        const length = this.g.zoomer.get("labelCustomColumnLengths") ? this.g.zoomer.get("labelCustomColumnLengths")[index] : this.g.zoomer.get("labelCustomValueDefaultLength");
-        var labelCustom = this.addEl(col, length);
-
-        labelHeader.appendChild(labelCustom);
-      });
+    if (this.g.vis.get("customColumnsGetter")) {
+      for(var idx = 0; idx < this.g.vis.get("customColumnsCount"); idx++) {
+        const column = this.g.vis.get("customColumnsGetter")(idx);
+        const length = column.length || 50;
+        const header = column.header;
+        if ( header instanceof Element || header instanceof HTMLDocument ) {
+          labelHeader.appendChild(header);
+        } 
+        else if (typeof header === 'function') {
+          const val = header();
+          const labelCustom = this.addEl(val, length);
+          labelHeader.appendChild(labelCustom);
+        }
+        else {
+          const labelCustom = this.addEl(header, length);
+          labelHeader.appendChild(labelCustom);
+        }
+      }
     }
-
     return labelHeader;
   },
 

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -87,33 +87,32 @@ const LabelView = view.extend({
     if (this.g.vis.get("customColumnsGetter")) {
       for (var idx = 0; idx < this.g.vis.get("customColumnsCount"); idx++) {
         const column = this.g.vis.get("customColumnsGetter")(idx);
-        const cell = column.cell;
-        var customValue = document.createElement("span");
-        var val;
+        const width = column.length || this.g.zoomer.get("customColumnsDefaultLength");
+        var cell = column.cell;
+        if (typeof cell === 'function') {
+          cell = cell(this.model.get("id"));
+        }
 
-        if ( cell instanceof Element || cell instanceof HTMLDocument) {
-          this.el.appendChild(cell);
-          continue;
+        if (!(cell instanceof Element )) {
+          cell = this.addEl(cell, width);
         }
-        else if ( typeof cell === 'function' ) {
-          val = cell(this.model.get("id"));
-          if (val instanceof Element ) {
-            this.el.appendChild(val);
-            continue;
-          } 
-        }
-        else {
-          val = cell;
-        }
-        customValue.textContent = val;
-        customValue.style.width = (column.length || this.g.zoomer.get("customColumnsDefaultLength")) + "px";
-        customValue.style.display = "inline-block";
-        this.el.appendChild(customValue);
+        this.el.appendChild(cell);
+
       }
     }
     this.el.style.overflow = scroll;
     this.el.style.fontSize = `${this.g.zoomer.get('labelFontsize')}px`;
     return this;
+  },
+
+  addEl: function(content, width) {
+    var id = document.createElement("span");
+    id.textContent = content;
+    if ((typeof width !== "undefined" && width !== null)) {
+      id.style.width = width + "px";
+    }
+    id.style.display = "inline-block";
+    return id;
   },
 
   _onclick: function(evt) {

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -88,30 +88,27 @@ const LabelView = view.extend({
       for (var idx = 0; idx < this.g.vis.get("customColumnsCount"); idx++) {
         const column = this.g.vis.get("customColumnsGetter")(idx);
         const cell = column.cell;
+        var customValue = document.createElement("span");
         var val;
 
         if ( cell instanceof Element || cell instanceof HTMLDocument) {
           this.el.appendChild(cell);
           continue;
         }
-        else {
-          var customValue = document.createElement("span");
-          var val;
-          if ( typeof cell === 'function' ) {
-            val = cell(this.model.toJSON());
-            if (val instanceof Element || val instanceof HTMLDocument) {
-              this.el.appendChild(val);
-              continue;
-            } 
-          }
-          else {
-            val = cell;
-          }
-          customValue.textContent = val;
-          customValue.style.width = (column.length || 50) + "px";
-          customValue.style.display = "inline-block";
-          this.el.appendChild(customValue);
+        else if ( typeof cell === 'function' ) {
+          val = cell(this.model.get("id"));
+          if (val instanceof Element ) {
+            this.el.appendChild(val);
+            continue;
+          } 
         }
+        else {
+          val = cell;
+        }
+        customValue.textContent = val;
+        customValue.style.width = (column.length || this.g.zoomer.get("customColumnsDefaultLength")) + "px";
+        customValue.style.display = "inline-block";
+        this.el.appendChild(customValue);
       }
     }
     this.el.style.overflow = scroll;

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -79,6 +79,7 @@ const LabelView = view.extend({
         name.style.fontWeight = "bold";
       }
       name.style.width= this.g.zoomer.get("labelNameLength") + "px";
+      name.style.display = "inline-block";
       this.el.appendChild(name);
       this.el.setAttribute("title", textContent)
     }
@@ -97,7 +98,7 @@ const LabelView = view.extend({
           var customValue = document.createElement("span");
           var val;
           if ( typeof cell === 'function' ) {
-            val = cell(this.model.get("id"), this.model.get("seq"));
+            val = cell(this.model.toJSON());
             if (val instanceof Element || val instanceof HTMLDocument) {
               this.el.appendChild(val);
               continue;

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -22,8 +22,8 @@ const LabelView = view.extend({
     this.delegateEvents(events);
     this.listenTo(this.g.config, "change:registerMouseHover", this.manageEvents);
     this.listenTo(this.g.config, "change:registerMouseClick", this.manageEvents);
-    this.listenTo(this.g.vis, "change:labelName change:labelId change:labelPartition change:labelCheckbox", this.render);
-    this.listenTo( this.g.zoomer, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength", this.render
+    this.listenTo(this.g.vis, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:labelCustomColumns change:labelCustomColumnsNames change:labelCustomColumnsValuesGetter", this.render);
+    this.listenTo( this.g.zoomer, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength change:labelCustomColumnLengths change:labelCustomValueDefaultLength", this.render
     );
     return this.listenTo( this.g.zoomer, "change:labelFontSize change:labelLineHeight change:labelWidth change:rowHeight", this.render
     );
@@ -83,6 +83,17 @@ const LabelView = view.extend({
       this.el.setAttribute("title", textContent)
     }
 
+    if (this.g.vis.get("labelCustomColumns")) {
+      this.g.vis.get("labelCustomColumnsNames").forEach((name, index) => {
+        var customValue = document.createElement("span");
+        const valFunc = this.g.vis.get("labelCustomColumnsValuesGetter")[index];
+        customValue.textContent = valFunc(this.model.get("id"), this.model.get("seq"));
+        customValue.name = name;
+        customValue.style.width = (this.g.zoomer.get("labelCustomColumnLengths") ? this.g.zoomer.get("labelCustomColumnLengths")[index] : this.g.zoomer.get("labelCustomValueDefaultLength")) + "px";
+        customValue.style.display = "inline-block";
+        this.el.appendChild(customValue);
+      });
+    }
     this.el.style.overflow = scroll;
     this.el.style.fontSize = `${this.g.zoomer.get('labelFontsize')}px`;
     return this;


### PR DESCRIPTION
Provided ability to render custom columns in the msa. 
To render custom columns user has to send 2 params 

1) customColumnsGetter : this is a custom getter function which will return information (cell, width, header) of custom columns, it will take index of the column as an arguement and will of the following signature: (index: number) => {width: number, cell: function || string || DOMElement, header: function || string || DOMElement}

2) customColumnsCount: number //number of custom columns

also added custom_columns example with different renders 
<img width="651" alt="Screenshot 2023-05-19 at 9 47 13 PM" src="https://github.com/pradeepnschrodinger/msa/assets/86060971/089a251d-1e74-47b9-a6eb-2749b4dbd3b3">
