### PR TITLE
Add ability to add custom columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,20 @@ vis: {
     labelPartition: false,
     labelCheckbox: false,
     labelIdentity: 'Ident',
+    /*
+    this can be overridden with a custom function of the following signature:
+        (index: number) => ColumnInfo
+      where ColumnInfo represents the details about a column:
+        {
+          width: number, 
+          header: (function | string | DOMElement),
+          cell: (function | string | DOMElement),
+        }
+      `header` or `cell` can also be a function of the following signature:
+        (seqId: string) => (string | DOMElement)
+    */
+    customColumnsGetter: undefined,
+    customColumnsCount: 0, // number of custom columns
 
     // meta stuff
     metaGaps: true,

--- a/snippets/custom_columns.js
+++ b/snippets/custom_columns.js
@@ -1,0 +1,79 @@
+var msa = window.msa;
+
+yourDiv.textContent = "loading";
+
+var opts = {};
+opts.el = yourDiv;
+
+const customValueCalculator = (id) => {
+  return id + " custom";
+}
+
+const getDomElement = (text, width) => {
+  const domEl = document.createElement("span")
+  domEl.classList.add("custom-column");
+  domEl.textContent = text;
+  domEl.style.width = width + "px";
+  domEl.style.display = "inline-block";
+  return domEl;
+}
+const customDomCalculator = (id) => {
+  const domEl = getDomElement("seq " + id, 90)
+  domEl.style.backgroundColor = "red";
+  return domEl;
+}
+
+const customColumns = [
+  {
+    header: 'Custom 1',
+    length: 90,
+    cell: customValueCalculator,
+  }, 
+  {
+    header: getDomElement("Custom 2", 120),
+    length: 120,
+    cell: 50,
+  },
+  {
+    header: 'Custom 3',
+    length: 90,
+    cell: customDomCalculator,
+  }
+]
+
+const customColumnCalculator = (idx) => {
+  return customColumns[idx];
+};
+
+opts.vis = {
+  conserv: false,
+  overviewbox: false,
+  customColumnsGetter: customColumnCalculator,
+  customColumnsCount: 3,
+  labelName: false,
+};
+opts.zoomer = {
+  boxRectHeight: 1,
+  boxRectWidth: 1,
+  alignmentHeight: window.innerHeight * 0.8,
+  labelFontsize: 12,
+  labelIdLength: 50,
+};
+var m = msa(opts);
+
+// the menu is independent to the MSA container
+var menuOpts = {};
+menuOpts.msa = m;
+var defMenu = new msa.menu.defaultmenu(menuOpts);
+m.addView("menu", defMenu);
+
+m.seqs.reset(msa.utils.seqgen.getDummySequences(20, 20));
+m.g.zoomer.set("alignmentWidth", "auto");
+m.render();
+renderMSA(msa.utils.seqgen.getDummySequences(20,20));
+
+function renderMSA(seqs) {
+  m.seqs.reset(seqs);
+  m.g.zoomer.set("alignmentWidth", "auto");
+  m.render();
+}

--- a/snippets/custom_columns.js
+++ b/snippets/custom_columns.js
@@ -5,7 +5,7 @@ yourDiv.textContent = "loading";
 var opts = {};
 opts.el = yourDiv;
 
-const customValueCalculator = (id) => {
+const getCustomText = (id) => {
   return id + " custom";
 }
 
@@ -17,7 +17,7 @@ const getDomElement = (text, width) => {
   domEl.style.display = "inline-block";
   return domEl;
 }
-const customDomCalculator = (id) => {
+const getStyledDiv = (id) => {
   const domEl = getDomElement("seq " + id, 90)
   domEl.style.backgroundColor = "red";
   return domEl;
@@ -27,7 +27,7 @@ const customColumns = [
   {
     header: 'Custom 1',
     length: 90,
-    cell: customValueCalculator,
+    cell: getCustomText,
   }, 
   {
     header: getDomElement("Custom 2", 120),
@@ -37,7 +37,7 @@ const customColumns = [
   {
     header: 'Custom 3',
     length: 90,
-    cell: customDomCalculator,
+    cell: getStyledDiv,
   }
 ]
 

--- a/src/g/visibility.js
+++ b/src/g/visibility.js
@@ -21,6 +21,7 @@ module.exports = Visibility = Model.extend({
     labelIdentity: 'Ident',
     labelPartition: false,
     labelCheckbox: false,
+    customColumnsCount: 0,
 
     // meta stuff
     metaGaps: true,
@@ -40,7 +41,7 @@ module.exports = Visibility = Model.extend({
     }), this
     );
 
-    this.listenTo( this, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:labelIdentity", (function() {
+    this.listenTo( this, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:labelIdentity change:customColumnsGetter change:customColumnsCount", (function() {
       return this.trigger("change:labels");
     }), this
     );

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -9,7 +9,7 @@ module.exports = Zoomer = Model.extend({
     this.g = options.g;
 
     // events
-    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength", (function() {
+    this.listenTo( this, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength change:customColumnsGetter change:customColumnsCount change:customColumnsDefaultLength", (function() {
       return this.trigger("change:labelWidth", this.getLabelWidth());
     }), this
     );
@@ -38,6 +38,7 @@ module.exports = Zoomer = Model.extend({
     labelCheckLength: 15,
     labelFontsize: 13,
     labelLineHeight: "13px",
+    customColumnsDefaultLength: 50,
 
     // marker
     markerFontsize: "10px",
@@ -128,6 +129,11 @@ module.exports = Zoomer = Model.extend({
      var val = 0;
      if (this.g.vis.get("labelName")) { val += this.get("labelNameLength"); }
      if (this.g.vis.get("labelId")) { val += this.get("labelIdLength"); }
+     if (this.g.vis.get("customColumnsGetter")) {
+        for (var idx = 0 ; idx < this.g.vis.get("customColumnsCount") ; idx++) {
+          val += this.g.vis.get("customColumnsGetter")(idx).length || this.get("customColumnsDefaultLength");
+        }
+     }
      if (this.g.vis.get("labelPartition")) { val += this.get("labelPartLength"); }
      if (this.g.vis.get("labelCheckbox")) { val += this.get("labelCheckLength"); }
      return val;

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -9,7 +9,7 @@ const LabelHeader = view.extend({
   initialize: function(data) {
     this.g = data.g;
 
-    this.listenTo(this.g.vis, "change:metacell change:labels", this.render);
+    this.listenTo(this.g.vis, "change:metacell change:labels change:customColumnsGetter change:customColumnsCount", this.render);
     return this.listenTo(this.g.zoomer, "change:labelWidth change:metaWidth", this.render);
   },
 
@@ -52,11 +52,27 @@ const LabelHeader = view.extend({
     }
 
     if (this.g.vis.get("labelName")) {
-      var name = this.addEl("Label");
+      var name = this.addEl("Label", this.g.zoomer.get("labelNameLength"));
       //name.style.marginLeft = "50px"
       labelHeader.appendChild(name);
     }
 
+    if (this.g.vis.get("customColumnsGetter")) {
+      for(var idx = 0; idx < this.g.vis.get("customColumnsCount"); idx++) {
+        const column = this.g.vis.get("customColumnsGetter")(idx);
+        const length = column.length || this.g.zoomer.get("customColumnsDefaultLength");
+        var header = column.header;
+        
+        if (typeof header === 'function') {
+          header = header();
+        }
+
+        if (!( header instanceof Element )) {
+          header = this.addEl(header, length);
+        } 
+        labelHeader.appendChild(header);
+      }
+    }
     return labelHeader;
   },
 

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -22,7 +22,7 @@ const LabelView = view.extend({
     this.delegateEvents(events);
     this.listenTo(this.g.config, "change:registerMouseHover", this.manageEvents);
     this.listenTo(this.g.config, "change:registerMouseClick", this.manageEvents);
-    this.listenTo(this.g.vis, "change:labelName change:labelId change:labelPartition change:labelCheckbox", this.render);
+    this.listenTo(this.g.vis, "change:labelName change:labelId change:labelPartition change:labelCheckbox change:customColumnsGetter change:customColumnsCount", this.render);
     this.listenTo( this.g.zoomer, "change:labelIdLength change:labelNameLength change:labelPartLength change:labelCheckLength", this.render
     );
     return this.listenTo( this.g.zoomer, "change:labelFontSize change:labelLineHeight change:labelWidth change:rowHeight", this.render
@@ -79,13 +79,40 @@ const LabelView = view.extend({
         name.style.fontWeight = "bold";
       }
       name.style.width= this.g.zoomer.get("labelNameLength") + "px";
+      name.style.display = "inline-block";
       this.el.appendChild(name);
       this.el.setAttribute("title", textContent)
     }
 
+    if (this.g.vis.get("customColumnsGetter")) {
+      for (var idx = 0; idx < this.g.vis.get("customColumnsCount"); idx++) {
+        const column = this.g.vis.get("customColumnsGetter")(idx);
+        const width = column.length || this.g.zoomer.get("customColumnsDefaultLength");
+        var cell = column.cell;
+        if (typeof cell === 'function') {
+          cell = cell(this.model.get("id"));
+        }
+
+        if (!(cell instanceof Element )) {
+          cell = this.addEl(cell, width);
+        }
+        this.el.appendChild(cell);
+
+      }
+    }
     this.el.style.overflow = scroll;
     this.el.style.fontSize = `${this.g.zoomer.get('labelFontsize')}px`;
     return this;
+  },
+
+  addEl: function(content, width) {
+    var id = document.createElement("span");
+    id.textContent = content;
+    if ((typeof width !== "undefined" && width !== null)) {
+      id.style.width = width + "px";
+    }
+    id.style.display = "inline-block";
+    return id;
   },
 
   _onclick: function(evt) {


### PR DESCRIPTION
Provided ability to render custom columns in the msa.
To render custom columns user has to send 2 params

customColumnsGetter : this is a custom getter function which will return information (cell, width, header) of custom columns, it will take index of the column as an arguement and will of the following signature: (index: number) => {width: number, cell: function || string || DOMElement, header: function || string || DOMElement}

customColumnsCount: number //number of custom columns

also added custom_columns example with different renders

<img width="651" alt="custom-columns" src="https://github.com/pradeepnschrodinger/msa/assets/86060971/2f2fa0fa-d9b8-4dec-a724-f736ebf58a39">
