### PR TITLE
Support pinned annotations and Improve rendering quality

### DIFF
--- a/css/msa.css
+++ b/css/msa.css
@@ -55,9 +55,13 @@
 }
 
 .biojs_msa_rheader {
-  display: flex;
-  overflow-x: auto;
   display: inline-block;
+  position: relative;
+}
+
+.biojs_msa_rheaders {
+  height: 100%;
+  overflow-x: auto;
 }
 
 .biojs_msa_labelblock::-webkit-scrollbar, .biojs_msa_rheader::-webkit-scrollbar{

--- a/css/msa.css
+++ b/css/msa.css
@@ -34,13 +34,14 @@
     text-align: left;
     display: flex;
     flex-direction: row;
+    border-bottom: 1px solid darkgray;
+    box-sizing: border-box;
 }
 
 .biojs_msa_headers {
     display: flex;
     height: 100%;
     border-right: 1px solid darkgray;
-    border-bottom: 1px solid darkgray;
     box-sizing: border-box;
 }
 

--- a/css/msa.css
+++ b/css/msa.css
@@ -39,6 +39,9 @@
 .biojs_msa_headers {
     display: flex;
     height: 100%;
+    border-right: 1px solid darkgray;
+    border-bottom: 1px solid darkgray;
+    box-sizing: border-box;
 }
 
 .biojs_msa_header_label {
@@ -62,6 +65,13 @@
 .biojs_msa_rheaders {
   height: 100%;
   overflow-x: auto;
+  position: relative;
+  z-index: 1; /* this makes the scrollbar display over pinned annotations" */
+}
+
+.biojs_msa_labelblock {
+  border-right: 1px solid darkgray;
+  box-sizing: border-box;
 }
 
 .biojs_msa_labelblock::-webkit-scrollbar, .biojs_msa_rheader::-webkit-scrollbar{

--- a/css/msa.css
+++ b/css/msa.css
@@ -32,6 +32,17 @@
 .biojs_msa_header {
     white-space: nowrap;
     text-align: left;
+    display: flex;
+    flex-direction: row;
+}
+
+.biojs_msa_headers {
+    display: flex;
+    height: 100%;
+}
+
+.biojs_msa_header_label {
+    align-self: flex-end;
 }
 
 .biojs_msa_labelrow {
@@ -41,6 +52,12 @@
 
 .biojs_msa_albody {
   display: flex;
+}
+
+.biojs_msa_rheader {
+  display: flex;
+  overflow-x: auto;
+  display: inline-block;
 }
 
 .biojs_msa_labelblock::-webkit-scrollbar, .biojs_msa_rheader::-webkit-scrollbar{

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -37,17 +37,17 @@ clustal.read(url, function(err, seqs) {
 });
 
 // add features
-// xhr("./data/fer1.gff3", function(err, request, body) {
-//   var features = gffParser.parseSeqs(body);
-//   m.seqs.addFeatures(features);
-//   m.render();
-// });
+xhr("./data/fer1.gff3", function(err, request, body) {
+  var features = gffParser.parseSeqs(body);
+  m.seqs.addFeatures(features);
+  m.render();
+});
 
-// xhr("./data/fer1.gff_jalview", function(err, request, body) {
-//   var features = gffParser.parseSeqs(body);
-//   m.seqs.addFeatures(features);
-//   m.render();
-// });
+xhr("./data/fer1.gff_jalview", function(err, request, body) {
+  var features = gffParser.parseSeqs(body);
+  m.seqs.addFeatures(features);
+  m.render();
+});
 
 // the menu is independent to the MSA container
 var defMenu = new msa.menu.defaultmenu({
@@ -56,26 +56,26 @@ var defMenu = new msa.menu.defaultmenu({
 });
 defMenu.render();
 
-const features = {
-  "config": {
-      "type": "gff3"
-  },
-  "seqs": {
-      "FER_CAPAN": [
-          {
-              "feature": "gene",
-              "pinned": true,
-              "start": 10,
-              "end": 15,
-              "attributes": {
-                  "Name": "A feature",
-                  "Color": "blue"
-              }
-          },
-      ],
-  }
-}
-m.seqs.addFeatures(features)
+// const features = {
+//   "config": {
+//       "type": "gff3"
+//   },
+//   "seqs": {
+//       "FER_CAPAN": [
+//           {
+//               "feature": "gene",
+//               "isPinned": true,
+//               "start": 10,
+//               "end": 15,
+//               "attributes": {
+//                   "Name": "A feature",
+//                   "Color": "blue"
+//               }
+//           },
+//       ],
+//   }
+// }
+// m.seqs.addFeatures(features)
 m.render();
 
 // BioJS event system test (you can safely remove this in your app)

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -24,7 +24,7 @@ opts.conf = {
 opts.vis = {
   conserv: false,
   overviewbox: false,
-  seqlogo: true
+  seqlogo: false
 };
 
 // init msa
@@ -37,15 +37,17 @@ clustal.read(url, function(err, seqs) {
 });
 
 // add features
-xhr("./data/fer1.gff3", function(err, request, body) {
-  var features = gffParser.parseSeqs(body);
-  m.seqs.addFeatures(features);
-});
+// xhr("./data/fer1.gff3", function(err, request, body) {
+//   var features = gffParser.parseSeqs(body);
+//   m.seqs.addFeatures(features);
+//   m.render();
+// });
 
-xhr("./data/fer1.gff_jalview", function(err, request, body) {
-  var features = gffParser.parseSeqs(body);
-  m.seqs.addFeatures(features);
-});
+// xhr("./data/fer1.gff_jalview", function(err, request, body) {
+//   var features = gffParser.parseSeqs(body);
+//   m.seqs.addFeatures(features);
+//   m.render();
+// });
 
 // the menu is independent to the MSA container
 var defMenu = new msa.menu.defaultmenu({
@@ -53,6 +55,28 @@ var defMenu = new msa.menu.defaultmenu({
   msa: m
 });
 defMenu.render();
+
+const features = {
+  "config": {
+      "type": "gff3"
+  },
+  "seqs": {
+      "FER_CAPAN": [
+          {
+              "feature": "gene",
+              "pinned": true,
+              "start": 10,
+              "end": 15,
+              "attributes": {
+                  "Name": "A feature",
+                  "Color": "blue"
+              }
+          },
+      ],
+  }
+}
+m.seqs.addFeatures(features)
+m.render();
 
 // BioJS event system test (you can safely remove this in your app)
 //instance=m.g

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -80,9 +80,27 @@ const features = [
       "start": 10,
       "end": 15,
       "attributes": {
-          "Name": "Neka Name",
+          "Name": "Nekadrew",
           "Color": "blue"
       }
+  },
+  {
+    "feature": "gene",
+    "start": 11,
+    "end": 16,
+    "attributes": {
+        "Name": "Niranjan",
+        "Color": "red"
+    }
+  },
+  {
+    "feature": "gene",
+    "start": 14,
+    "end": 20,
+    "attributes": {
+        "Name": "Shweta",
+        "Color": "yellow"
+    }
   },
 ];
 m.pinnedFeatures.reset(features)

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -56,70 +56,51 @@ var defMenu = new msa.menu.defaultmenu({
 });
 defMenu.render();
 
-// const features = {
-//   "config": {
-//       "type": "gff3"
-//   },
-//   "seqs": {
-//       "FER_CAPAN": [
-//           {
-//               "feature": "gene",
-//               "start": 10,
-//               "end": 15,
-//               "attributes": {
-//                   "Name": "A feature",
-//                   "Color": "blue"
-//               }
-//           },
-//       ],
-//   }
-// }
-const features = [
+// pin features
+const pinnedFeatures = [
   {
       "feature": "gene",
-      "start": 10,
-      "end": 15,
+      "start": 0,
+      "end": 100,
       "attributes": {
-          "Name": "Nekadrew",
+          "Name": "VH",
           "Color": "#E5FCDD",
           "textColor": "#71B567",
         }
       },
       {
         "feature": "gene",
-        "start": 11,
-        "end": 16,
+        "start": 0,
+        "end": 20,
         "attributes": {
-          "Name": "Niranjan",
+          "Name": "HFR1",
           "Color": "#E5FCDD",
           "textColor": "#71B567",
     }
   },
   {
     "feature": "gene",
-    "start": 16,
-    "end": 35,
+    "start": 21,
+    "end": 30,
     "attributes": {
-        "Name": "Nekadrew",
+        "Name": "H1",
         "Color": "#E5FCDD",
         "textColor": "#71B567",
     }
   },
   {
     "feature": "gene",
-    "start": 14,
-    "end": 20,
+    "start": 36,
+    "end": 40,
     "attributes": {
-        "Name": "Shweta",
+        "Name": "HFR2",
         "Color": "#E5FCDD",
         "textColor": "#71B567",
     }
   },
 ];
-setTimeout(() => {
-  m.pinnedFeatures.reset(features)
-  m.render();
-}, 0)
+m.pinnedFeatures.reset(pinnedFeatures)
+m.render();
 
 // BioJS event system test (you can safely remove this in your app)
 //instance=m.g

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -90,7 +90,7 @@ const features = [
     "end": 16,
     "attributes": {
         "Name": "Niranjan",
-        "Color": "red"
+        "Color": "blue"
     }
   },
   {

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -95,6 +95,15 @@ const features = [
   },
   {
     "feature": "gene",
+    "start": 16,
+    "end": 35,
+    "attributes": {
+        "Name": "Nekadrew",
+        "Color": "blue"
+    }
+  },
+  {
+    "feature": "gene",
     "start": 14,
     "end": 20,
     "attributes": {
@@ -103,8 +112,10 @@ const features = [
     }
   },
 ];
-m.pinnedFeatures.reset(features)
-m.render();
+setTimeout(() => {
+  m.pinnedFeatures.reset(features)
+  m.render();
+}, 0)
 
 // BioJS event system test (you can safely remove this in your app)
 //instance=m.g

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -81,16 +81,18 @@ const features = [
       "end": 15,
       "attributes": {
           "Name": "Nekadrew",
-          "Color": "blue"
-      }
-  },
-  {
-    "feature": "gene",
-    "start": 11,
-    "end": 16,
-    "attributes": {
-        "Name": "Niranjan",
-        "Color": "blue"
+          "Color": "#E5FCDD",
+          "textColor": "#71B567",
+        }
+      },
+      {
+        "feature": "gene",
+        "start": 11,
+        "end": 16,
+        "attributes": {
+          "Name": "Niranjan",
+          "Color": "#E5FCDD",
+          "textColor": "#71B567",
     }
   },
   {
@@ -99,7 +101,8 @@ const features = [
     "end": 35,
     "attributes": {
         "Name": "Nekadrew",
-        "Color": "blue"
+        "Color": "#E5FCDD",
+        "textColor": "#71B567",
     }
   },
   {
@@ -108,7 +111,8 @@ const features = [
     "end": 20,
     "attributes": {
         "Name": "Shweta",
-        "Color": "yellow"
+        "Color": "#E5FCDD",
+        "textColor": "#71B567",
     }
   },
 ];

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -64,7 +64,6 @@ defMenu.render();
 //       "FER_CAPAN": [
 //           {
 //               "feature": "gene",
-//               "isPinned": true,
 //               "start": 10,
 //               "end": 15,
 //               "attributes": {
@@ -75,7 +74,18 @@ defMenu.render();
 //       ],
 //   }
 // }
-// m.seqs.addFeatures(features)
+const features = [
+  {
+      "feature": "gene",
+      "start": 10,
+      "end": 15,
+      "attributes": {
+          "Name": "Neka Name",
+          "Color": "blue"
+      }
+  },
+];
+m.pinnedFeatures.reset(features)
 m.render();
 
 // BioJS event system test (you can safely remove this in your app)

--- a/src/model/Feature.js
+++ b/src/model/Feature.js
@@ -6,6 +6,7 @@ const Feature = Model.extend({
     xEnd: -1,
     height: -1,
     text: "",
+    textColor: "black",
     fillColor: "red",
     fillOpacity: 0.5,
     type: "rectangle",
@@ -32,6 +33,9 @@ const Feature = Model.extend({
       }
       if ((obj.attributes.Color != null)) {
         this.set("fillColor", obj.attributes.Color);
+      }
+      if ((obj.attributes.textColor != null)) {
+        this.set("textColor", obj.attributes.textColor);
       }
     }
 

--- a/src/model/FeatureCol.js
+++ b/src/model/FeatureCol.js
@@ -10,9 +10,10 @@ const FeatureCol = Collection.extend({
     this.startOnCache = [];
     // invalidate cache
     this.on( "all", (function() {
+      this.assignRows();
       return this.startOnCache = [];
     }), this);
-    return Collection.apply(this, arguments);
+    Collection.apply(this, arguments);
   },
 
   // returns all features starting on index
@@ -38,7 +39,9 @@ const FeatureCol = Collection.extend({
   // tries to auto-fit the rows
   // not a very efficient algorithm
   assignRows: function() {
-
+    if (this.length === 0) {
+      return;
+    }
     const len = (this.max(function(el) { return el.get("xEnd"); })).attributes.xEnd;
     const rows = (() => {
       const result = [];

--- a/src/model/FeatureCol.js
+++ b/src/model/FeatureCol.js
@@ -68,6 +68,9 @@ const FeatureCol = Collection.extend({
   },
 
   getCurrentHeight: function() {
+    if (this.length === 0) {
+      return 1;
+    }
     return (this.max(function(el) { return el.get("row"); })).attributes.row + 1;
   },
 

--- a/src/msa.js
+++ b/src/msa.js
@@ -29,6 +29,7 @@ const $ = require("jbone");
 import FileHelper from "./utils/file";
 import TreeHelper from "./utils/tree";
 import ProxyHelper from "./utils/proxy";
+import FeatureCol from "./model/FeatureCol";
 
 // opts is a dictionary consisting of
 // @param el [String] id or reference to a DOM element
@@ -56,6 +57,7 @@ const MSA = boneView.extend({
 
     // load seqs and add subviews
     this.seqs = this.g.seqs = new SeqCollection(data.seqs, this.g);
+    this.pinnedFeatures = this.g.pinnedFeatures = new FeatureCol();
 
     // populate it and init the global models
     this.g.config = new Config(data.conf);

--- a/src/utils/canvas.js
+++ b/src/utils/canvas.js
@@ -1,0 +1,25 @@
+
+// NOTE (pradeep): Basic canvas that renders contents at a higher resolution for clarity
+const hdCanvas = (opts = {}) => {
+  const height = opts.height || 100
+  const width = opts.width || 100
+
+  const canvas = document.createElement("canvas");
+  canvas.adjustSize = adjustSize;
+  canvas.adjustSize({ height, width })
+
+  return canvas;
+}
+
+const adjustSize = function ({ height, width }) {
+  // TODO (pradeep): Use devicepixelratio here?
+  const sharpnessFactor = 2;
+
+  this.setAttribute('height', height * sharpnessFactor + "px");
+  this.style.height = height + "px";
+  this.setAttribute('width', width * sharpnessFactor + "px");
+  this.style.width = width + "px";
+  this.getContext('2d').scale(sharpnessFactor, sharpnessFactor);
+};
+
+export { hdCanvas }

--- a/src/views/AlignmentBody.js
+++ b/src/views/AlignmentBody.js
@@ -1,4 +1,5 @@
 const boneView = require("backbone-childs");
+import { hdCanvas } from "../utils/canvas";
 import SeqBlock from "./canvas/CanvasSeqBlock";
 import LabelBlock from "./labels/LabelBlock";
 
@@ -26,7 +27,7 @@ const View = boneView.extend({
         seqblock = new SeqBlock({
           model: this.model,
           g: this.g,
-          el: document.createElement("canvas"),
+          el: hdCanvas(),
         });
       }
       seqblock.ordering = 0;

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -30,9 +30,14 @@ class CanvasCharCache {
   createTile(letter, width, height) {
 
     const canvas = this.cache[letter] = document.createElement("canvas");
-    canvas.width = width;
-    canvas.height = height;
+    const sharpnessFactor = 2;
+    canvas.setAttribute('height', height * sharpnessFactor + "px");
+    canvas.style.height = height + "px";
+    canvas.setAttribute('width', width * sharpnessFactor + "px");
+    canvas.style.width = width + "px";
+    
     this.ctx = canvas.getContext('2d');
+    this.ctx.setTransform(sharpnessFactor, 0, 0, sharpnessFactor, 0, 0);
     this.ctx.font = this.g.zoomer.get("residueFont") + "px mono";
 
     this.ctx.textBaseline = 'middle';

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -1,3 +1,5 @@
+import { hdCanvas } from "../../utils/canvas";
+
 const Events = require("biojs-events");
 
 class CanvasCharCache {
@@ -28,16 +30,9 @@ class CanvasCharCache {
   // creates a canvas with a single letter
   // (for the fast font cache)
   createTile(letter, width, height) {
-
-    const canvas = this.cache[letter] = document.createElement("canvas");
-    const sharpnessFactor = 2;
-    canvas.setAttribute('height', height * sharpnessFactor + "px");
-    canvas.style.height = height + "px";
-    canvas.setAttribute('width', width * sharpnessFactor + "px");
-    canvas.style.width = width + "px";
-    
+    const canvas = this.cache[letter] = hdCanvas();
     this.ctx = canvas.getContext('2d');
-    this.ctx.setTransform(sharpnessFactor, 0, 0, sharpnessFactor, 0, 0);
+    canvas.adjustSize({ height, width })
     this.ctx.font = this.g.zoomer.get("residueFont") + "px mono";
 
     this.ctx.textBaseline = 'middle';

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -1,9 +1,11 @@
 import {extend} from "lodash";
+import { hdCanvas } from "../../utils/canvas";
 const boneView = require("backbone-childs");
 
 const CanvasPinnedBlock = boneView.extend({
   initialize(data) {
     this.g = data.g;
+    this.el = hdCanvas();
     this.ctx = this.el.getContext('2d');
     this.model = data.model;
     this.width = data.width;
@@ -30,14 +32,7 @@ const CanvasPinnedBlock = boneView.extend({
   adjustSize() {
     const height = (this.g.zoomer.get('rowHeight') * this.model.getCurrentHeight());
     const width = this.g.zoomer.getAlignmentWidth();
-    // NOTE (pradeep): Sharpness factor is used to render the canvas at a higher resolution for clarity
-    const sharpnessFactor = 2;
-
-    this.el.setAttribute('height', height * sharpnessFactor + "px");
-    this.el.style.height = height;
-    this.el.setAttribute('width', width * sharpnessFactor + "px");
-    this.el.style.width = width;
-    this.ctx.scale(sharpnessFactor, sharpnessFactor);
+    this.el.adjustSize({ width, height })
   },
 
   render() {
@@ -48,7 +43,7 @@ const CanvasPinnedBlock = boneView.extend({
   drawFeatures() {
     const rectWidth = this.g.zoomer.get("columnWidth");
     const rectHeight = this.g.zoomer.get("rowHeight");
-    const borderWidth = 1.5;
+    const borderWidth = 0.75;
     const xOffset = this.getXOffset(rectWidth);
 
     this.model.forEach((feature) => {

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -28,8 +28,16 @@ const CanvasPinnedBlock = boneView.extend({
   },
 
   adjustSize() {
-    this.el.setAttribute('height', this.g.zoomer.get('rowHeight') * this.model.getCurrentHeight() + "px");
-    this.el.setAttribute('width', this.g.zoomer.getAlignmentWidth() + "px");
+    const height = (this.g.zoomer.get('rowHeight') * this.model.getCurrentHeight());
+    const width = this.g.zoomer.getAlignmentWidth();
+    // NOTE (pradeep): Sharpness factor is used to render the canvas at a higher resolution for clarity
+    const sharpnessFactor = 2;
+
+    this.el.setAttribute('height', height * sharpnessFactor + "px");
+    this.el.style.height = height;
+    this.el.setAttribute('width', width * sharpnessFactor + "px");
+    this.el.style.width = width;
+    this.ctx.scale(sharpnessFactor, sharpnessFactor);
   },
 
   render() {
@@ -40,6 +48,7 @@ const CanvasPinnedBlock = boneView.extend({
   drawFeatures() {
     const rectWidth = this.g.zoomer.get("columnWidth");
     const rectHeight = this.g.zoomer.get("rowHeight");
+    const borderWidth = 1.5;
     const xOffset = this.getXOffset(rectWidth);
 
     this.model.forEach((feature) => {
@@ -47,10 +56,16 @@ const CanvasPinnedBlock = boneView.extend({
       const y = (feature.attributes.row || 0) * rectWidth;
       const width = (feature.attributes.xEnd - feature.attributes.xStart + 1) * rectWidth;
       const height = 1 * rectHeight;
-      
-      // draw background block
+  
+      // draw background border
+      this.ctx.globalAlpha = 1;
       this.ctx.fillStyle = feature.attributes.fillColor;
       this.ctx.fillRect(x + xOffset, y, width, height);
+
+      // draw background block border
+      this.ctx.strokeStyle = 'black';
+      this.ctx.lineWidth = borderWidth;
+      this.ctx.strokeRect(x + xOffset, y, width, height);
 
       // draw text
       this.ctx.fillStyle = "black";

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -8,12 +8,6 @@ const CanvasPinnedBlock = boneView.extend({
     this.el = hdCanvas();
     this.ctx = this.el.getContext('2d');
     this.model = data.model;
-    this.width = data.width;
-    this.height = data.height;
-    this.color = data.color;
-    this.cache = data.cache;
-    this.rectHeight = this.g.zoomer.get("rowHeight");
-    this.rectWidth = this.g.zoomer.get("columnWidth");
 
     this.setupListeners();
   },

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -28,44 +28,23 @@ const CanvasPinnedBlock = boneView.extend({
   },
 
   adjustSize() {
-    this.el.setAttribute('height', this.g.zoomer.get('rowHeight') * 2 + "px");
+    this.el.setAttribute('height', this.g.zoomer.get('rowHeight') * this.model.getCurrentHeight() + "px");
     this.el.setAttribute('width', this.g.zoomer.getAlignmentWidth() + "px");
   },
 
   render() {
     this.adjustSize();
-    this.drawPinnedFeatures();
+    this.drawFeatures();
   },
 
-  drawPinnedFeatures() {
-    // const record = {
-    //   "feature": "gene",
-    //   "start": 10,
-    //   "end": 15,
-    //   "attributes": {
-    //       "Name": "Neka Name",
-    //       "Color": "blue"
-    //   },
-    //   "xStart": 9,
-    //   "xEnd": 14,
-    //   "height": -1,
-    //   "text": "Neka Name",
-    //   "fillColor": "blue",
-    //   "fillOpacity": 0.5,
-    //   "type": "rectangle",
-    //   "borderSize": 1,
-    //   "borderColor": "black",
-    //   "borderOpacity": 0.5,
-    //   "validate": true,
-    //   "row": 0
-    // }
+  drawFeatures() {
     const rectWidth = this.g.zoomer.get("columnWidth");
-    const rectHeight = this.g.zoomer.get("rowHeight");  
+    const rectHeight = this.g.zoomer.get("rowHeight");
     const xOffset = this.getXOffset(rectWidth);
 
     this.model.forEach((feature) => {
       const x = feature.attributes.xStart * rectWidth;
-      const y = ((feature.attributes.row || 0) + 1) * rectWidth;
+      const y = (feature.attributes.row || 0) * rectWidth;
       const width = (feature.attributes.xEnd - feature.attributes.xStart + 1) * rectWidth;
       const height = 1 * rectHeight;
       

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -69,8 +69,21 @@ const CanvasPinnedBlock = boneView.extend({
       const width = (feature.attributes.xEnd - feature.attributes.xStart + 1) * rectWidth;
       const height = 1 * rectHeight;
       
+      // draw background block
       this.ctx.fillStyle = feature.attributes.fillColor;
       this.ctx.fillRect(x + xOffset, y, width, height);
+
+      // draw text
+      this.ctx.fillStyle = "black";
+      this.ctx.font = this.g.zoomer.get("residueFont") + "px mono";
+      this.ctx.textBaseline = 'middle';
+      this.ctx.textAlign = "center";
+
+      this.ctx.fillText(
+        feature.attributes.text, 
+        x + width/2 + xOffset,
+        y + height/2,
+      );
     })
   },
 

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -42,9 +42,9 @@ const CanvasPinnedBlock = boneView.extend({
 
     // TODO (pradeep): Perform virtualization here?
     this.model.forEach((feature) => {
-      const x = feature.attributes.xStart * rectWidth;
+      const x = feature.attributes.start * rectWidth;
       const y = (feature.attributes.row || 0) * rectWidth;
-      const width = (feature.attributes.xEnd - feature.attributes.xStart + 1) * rectWidth;
+      const width = (feature.attributes.end - feature.attributes.start + 1) * rectWidth;
       const height = 1 * rectHeight;
   
       // draw background border

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -1,0 +1,89 @@
+import {extend} from "lodash";
+const boneView = require("backbone-childs");
+
+const CanvasPinnedBlock = boneView.extend({
+  initialize(data) {
+    this.g = data.g;
+    this.ctx = this.el.getContext('2d');
+    this.model = data.model;
+    this.width = data.width;
+    this.height = data.height;
+    this.color = data.color;
+    this.cache = data.cache;
+    this.rectHeight = this.g.zoomer.get("rowHeight");
+    this.rectWidth = this.g.zoomer.get("columnWidth");
+
+    this.setupListeners();
+  },
+
+  setupListeners() {
+    this.listenTo(
+      this.g.zoomer, 
+      "change:_alignmentScrollLeft change:_alignmentScrollTop change:alignmentWidth change:alignmentHeight", 
+      function(model, value, options) {
+        if ((!(((typeof options !== "undefined" && options !== null) ? options.origin : undefined) != null)) || options.origin !== "canvasseq") {
+          return this.render();
+        }
+    });
+  },
+
+  adjustSize() {
+    this.el.setAttribute('height', this.g.zoomer.get('rowHeight') * 2 + "px");
+    this.el.setAttribute('width', this.g.zoomer.getAlignmentWidth() + "px");
+  },
+
+  render() {
+    this.adjustSize();
+    this.drawPinnedFeatures();
+  },
+
+  drawPinnedFeatures() {
+    // const record = {
+    //   "feature": "gene",
+    //   "start": 10,
+    //   "end": 15,
+    //   "attributes": {
+    //       "Name": "Neka Name",
+    //       "Color": "blue"
+    //   },
+    //   "xStart": 9,
+    //   "xEnd": 14,
+    //   "height": -1,
+    //   "text": "Neka Name",
+    //   "fillColor": "blue",
+    //   "fillOpacity": 0.5,
+    //   "type": "rectangle",
+    //   "borderSize": 1,
+    //   "borderColor": "black",
+    //   "borderOpacity": 0.5,
+    //   "validate": true,
+    //   "row": 0
+    // }
+    const rectWidth = this.g.zoomer.get("columnWidth");
+    const rectHeight = this.g.zoomer.get("rowHeight");  
+    const xOffset = this.getXOffset(rectWidth);
+
+    this.model.forEach((feature) => {
+      const x = feature.attributes.xStart * rectWidth;
+      const y = ((feature.attributes.row || 0) + 1) * rectWidth;
+      const width = (feature.attributes.xEnd - feature.attributes.xStart + 1) * rectWidth;
+      const height = 1 * rectHeight;
+      
+      this.ctx.fillStyle = feature.attributes.fillColor;
+      this.ctx.fillRect(x + xOffset, y, width, height);
+    })
+  },
+
+  getXOffset(rectWidth) {
+    // NOTE (pradeep): I have no idea what the calculation here does besides just
+    // adjusting an offset based on current alignment/scroll offset.
+    // This is copied from views/FeatureBlock.js
+    var start = Math.max(0, Math.abs(Math.ceil( - this.g.zoomer.get('_alignmentScrollLeft') / rectWidth)));
+    var x = - Math.abs( - this.g.zoomer.get('_alignmentScrollLeft') % rectWidth);
+    var xZero = x - start * rectWidth;
+
+    return xZero;
+  }
+})
+
+export default CanvasPinnedBlock;

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -46,6 +46,7 @@ const CanvasPinnedBlock = boneView.extend({
     const borderWidth = 0.75;
     const xOffset = this.getXOffset(rectWidth);
 
+    // TODO (pradeep): Perform virtualization here?
     this.model.forEach((feature) => {
       const x = feature.attributes.xStart * rectWidth;
       const y = (feature.attributes.row || 0) * rectWidth;
@@ -63,8 +64,8 @@ const CanvasPinnedBlock = boneView.extend({
       this.ctx.strokeRect(x + xOffset, y, width, height);
 
       // draw text
-      this.ctx.fillStyle = "black";
-      this.ctx.font = this.g.zoomer.get("residueFont") + "px mono";
+      this.ctx.fillStyle = feature.attributes.textColor || "black";
+      this.ctx.font = 'bold ' + this.g.zoomer.get("residueFont") + "px mono";
       this.ctx.textBaseline = 'middle';
       this.ctx.textAlign = "center";
 

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -12,7 +12,6 @@ const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
-    this.isPinned = data.isPinned;
 
     this.listenTo(this.g.zoomer, "change:_alignmentScrollLeft change:_alignmentScrollTop", function(model,value, options) {
       if ((!(((typeof options !== "undefined" && options !== null) ? options.origin : undefined) != null)) || options.origin !== "canvasseq") {
@@ -139,13 +138,10 @@ const View = boneView.extend({
 
     // draw all the stuff
     if ((this.seqDrawer != null)  && this.model.length > 0) {
-      // NOTE (pradeep): We don't support pinned sequences yet
-      if (!this.isPinned) {
-        // char based
-        this.seqDrawer.drawLetters();
-        // row based
-        this.seqDrawer.drawRows(this.sel._appendSelection, this.sel);
-      }
+      // char based
+      this.seqDrawer.drawLetters();
+      // row based
+      this.seqDrawer.drawRows(this.sel._appendSelection, this.sel);
 
       // draw features
       return this.seqDrawer.drawRows(this.drawFeatures, this);
@@ -159,9 +155,6 @@ const View = boneView.extend({
       const ctx = this.ctx;
       // draw background
       data.model.attributes.features.each((feature) => {
-        if (feature.attributes.isPinned != this.isPinned) {
-          return;
-        }
         ctx.fillStyle = feature.attributes.fillColor || "red";
         const len = feature.attributes.xEnd - feature.attributes.xStart + 1;
         const y = (feature.attributes.row + 1) * rectHeight;
@@ -175,9 +168,6 @@ const View = boneView.extend({
       ctx.textAlign = "center";
 
       return data.model.attributes.features.each((feature) => {
-        if (feature.attributes.isPinned != this.isPinned) {
-          return;
-        }
         const len = feature.attributes.xEnd - feature.attributes.xStart + 1;
         const y = (feature.attributes.row + 1) * rectHeight;
         return ctx.fillText( feature.attributes.text, data.xZero + feature.attributes.xStart *
@@ -188,9 +178,6 @@ const View = boneView.extend({
   },
 
   getPlannedElHeight() {
-    if (this.isPinned) {
-      return this.g.zoomer.get('rowHeight') * 2;
-    }
     return this.g.zoomer.get("alignmentHeight");
   },
 
@@ -216,13 +203,11 @@ const View = boneView.extend({
     }
 
 
-    if (!this.isPinned) {
-      const zoomerScrollLeft = this.g.zoomer.get('_alignmentScrollLeft');
-      const zoomerScrollTop = this.g.zoomer.get('_alignmentScrollTop');
-      const scrollObj = this._checkScrolling( [ zoomerScrollLeft, zoomerScrollTop ])
-  
-      this.g.zoomer._checkScrolling( scrollObj, {header: "canvasseq"});
-    }
+    const zoomerScrollLeft = this.g.zoomer.get('_alignmentScrollLeft');
+    const zoomerScrollTop = this.g.zoomer.get('_alignmentScrollTop');
+    const scrollObj = this._checkScrolling( [ zoomerScrollLeft, zoomerScrollTop ])
+
+    this.g.zoomer._checkScrolling( scrollObj, {header: "canvasseq"});
 
     this._setColor();
 
@@ -231,7 +216,6 @@ const View = boneView.extend({
       height: this.el.height,
       color: this.color,
       cache: this.cache,
-      isPinned: this.isPinned,
     });
 
     this.throttledDraw();

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -131,9 +131,7 @@ const View = boneView.extend({
 
   draw: function() {
     if (!(this.g.config.get("shouldRenderSeqBlockAsSvg") === true)) {
-      // fastest way to clear the canvas
-      // http://jsperf.com/canvas-clear-speed/25
-      this.el.width = this.el.width;
+      this.ctx.clearRect(0, 0, this.el.width, this.el.height)
     }
 
     // draw all the stuff
@@ -192,8 +190,10 @@ const View = boneView.extend({
       this.el.style.width = `${this.getPlannedElWidth()}px`;
       this.el.style.height = `${this.getPlannedElHeight()}px`;
     } else {
-      this.el.setAttribute('height', this.getPlannedElHeight() + "px");
-      this.el.setAttribute('width', this.getPlannedElWidth() + "px");
+      this.el.adjustSize({
+        height: this.getPlannedElHeight(),
+        width: this.getPlannedElWidth(),
+      })
     }
 
     if (this.g.config.get("shouldRenderSeqBlockAsSvg") === true) {

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -454,7 +454,6 @@ const View = boneView.extend({
       }
     }
 
-    console.log(scrollObj)
     return scrollObj;
   }
 });

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -139,10 +139,15 @@ const View = boneView.extend({
 
     // draw all the stuff
     if ((this.seqDrawer != null)  && this.model.length > 0) {
-      // char based
-      this.seqDrawer.drawLetters();
-      // row based
-      this.seqDrawer.drawRows(this.sel._appendSelection, this.sel);
+      // NOTE (pradeep): We don't support pinned sequences yet
+      if (!this.isPinned) {
+        // char based
+        this.seqDrawer.drawLetters();
+        // row based
+        this.seqDrawer.drawRows(this.sel._appendSelection, this.sel);
+      }
+
+      // draw features
       return this.seqDrawer.drawRows(this.drawFeatures, this);
     }
   },
@@ -152,7 +157,11 @@ const View = boneView.extend({
     const rectHeight = this.g.zoomer.get("rowHeight");
     if (data.model.attributes.height > 1) {
       const ctx = this.ctx;
-      data.model.attributes.features.each(function(feature) {
+      // draw background
+      data.model.attributes.features.each((feature) => {
+        if (feature.attributes.isPinned != this.isPinned) {
+          return;
+        }
         ctx.fillStyle = feature.attributes.fillColor || "red";
         const len = feature.attributes.xEnd - feature.attributes.xStart + 1;
         const y = (feature.attributes.row + 1) * rectHeight;
@@ -165,7 +174,10 @@ const View = boneView.extend({
       ctx.textBaseline = 'middle';
       ctx.textAlign = "center";
 
-      return data.model.attributes.features.each(function(feature) {
+      return data.model.attributes.features.each((feature) => {
+        if (feature.attributes.isPinned != this.isPinned) {
+          return;
+        }
         const len = feature.attributes.xEnd - feature.attributes.xStart + 1;
         const y = (feature.attributes.row + 1) * rectHeight;
         return ctx.fillText( feature.attributes.text, data.xZero + feature.attributes.xStart *

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -204,19 +204,22 @@ const View = boneView.extend({
     }
 
 
-    const zoomerScrollLeft = this.g.zoomer.get('_alignmentScrollLeft');
-    const zoomerScrollRight = this.g.zoomer.get('_alignmentScrollTop');
-    const scrollObj = this._checkScrolling( [ zoomerScrollLeft, zoomerScrollRight ])
-
-    this.g.zoomer._checkScrolling( scrollObj, {header: "canvasseq"});
+    if (!this.isPinned) {
+      const zoomerScrollLeft = this.g.zoomer.get('_alignmentScrollLeft');
+      const zoomerScrollTop = this.g.zoomer.get('_alignmentScrollTop');
+      const scrollObj = this._checkScrolling( [ zoomerScrollLeft, zoomerScrollTop ])
+  
+      this.g.zoomer._checkScrolling( scrollObj, {header: "canvasseq"});
+    }
 
     this._setColor();
 
-    this.seqDrawer = new CanvasSeqDrawer( this.g,this.ctx,this.model,
-      {width: this.el.width,
+    this.seqDrawer = new CanvasSeqDrawer( this.g,this.ctx,this.model, {
+      width: this.el.width,
       height: this.el.height,
       color: this.color,
-      cache: this.cache
+      cache: this.cache,
+      isPinned: this.isPinned,
     });
 
     this.throttledDraw();

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -12,6 +12,7 @@ const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
+    this.isPinned = data.isPinned;
 
     this.listenTo(this.g.zoomer, "change:_alignmentScrollLeft change:_alignmentScrollTop", function(model,value, options) {
       if ((!(((typeof options !== "undefined" && options !== null) ? options.origin : undefined) != null)) || options.origin !== "canvasseq") {
@@ -175,6 +176,9 @@ const View = boneView.extend({
   },
 
   getPlannedElHeight() {
+    if (this.isPinned) {
+      return this.g.zoomer.get('rowHeight') * 2;
+    }
     return this.g.zoomer.get("alignmentHeight");
   },
 
@@ -451,6 +455,7 @@ const View = boneView.extend({
       }
     }
 
+    console.log(scrollObj)
     return scrollObj;
   }
 });

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -34,13 +34,14 @@ const Drawer = {
 
     for (let i = start; i < this.model.length; i++) {
       const seq = this.model.at(i);
-      if (seq.get('hidden')) {
+      if (seq.get('hidden') || (this.isPinned != seq.get('isPinned'))) {
         continue;
       }
       callback.call(target, {model: seq, yPos: y, y: i, hidden: hidden});
 
-      const seqHeight = (seq.attributes.height || 1) * this.rectHeight;
-      y = y + seqHeight;
+      const pinnedAttributesHeight = seq.attributes.features.filter(feature => feature.attributes.isPinned).length;
+      const attributesCount = this.isPinned ? pinnedAttributesHeight : (seq.attributes.height - pinnedAttributesHeight)
+      y = y + (attributesCount *  this.rectHeight);
 
       // out of viewport - stop
       if (y > this.height) {

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -34,14 +34,11 @@ const Drawer = {
 
     for (let i = start; i < this.model.length; i++) {
       const seq = this.model.at(i);
-      if (seq.get('hidden') || (this.isPinned != seq.get('isPinned'))) {
+      if (seq.get('hidden')) {
         continue;
       }
       callback.call(target, {model: seq, yPos: y, y: i, hidden: hidden});
-
-      const pinnedAttributesHeight = seq.attributes.features.filter(feature => feature.attributes.isPinned).length;
-      const attributesCount = this.isPinned ? pinnedAttributesHeight : (seq.attributes.height - pinnedAttributesHeight)
-      y = y + (attributesCount *  this.rectHeight);
+      y = y + (seq.attributes.height *  this.rectHeight);
 
       // out of viewport - stop
       if (y > this.height) {
@@ -69,8 +66,8 @@ const Drawer = {
   // returns first sequence in the viewport
   // y is the position to start drawing
   getStartSeq: function() {
-    const alignmentScrollTop = this.isPinned ? 0 : this.g.zoomer.get('_alignmentScrollTop');
-    const start = (Math.max(0, Math.floor( alignmentScrollTop / this.rectHeight))) + 1;
+    const alignmentScrollTop = this.g.zoomer.get('_alignmentScrollTop');
+    const start = (Math.max(0, Math.floor(alignmentScrollTop / this.rectHeight))) + 1;
     let counter = 0;
     let i = 0;
     while (counter < start && i < this.model.length) {
@@ -173,7 +170,6 @@ const CanvasSeqDrawer = function(g,ctx,model,opts) {
   this.height = opts.height;
   this.color = opts.color;
   this.cache = opts.cache;
-  this.isPinned = opts.isPinned;
   this.rectHeight = this.g.zoomer.get("rowHeight");
   this.rectWidth = this.g.zoomer.get("columnWidth"); // note: this can change
   return this;

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -38,7 +38,9 @@ const Drawer = {
         continue;
       }
       callback.call(target, {model: seq, yPos: y, y: i, hidden: hidden});
-      y = y + (seq.attributes.height *  this.rectHeight);
+
+      const seqHeight = (seq.attributes.height || 1) * this.rectHeight;
+      y = y + seqHeight;
 
       // out of viewport - stop
       if (y > this.height) {

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -68,14 +68,15 @@ const Drawer = {
   // returns first sequence in the viewport
   // y is the position to start drawing
   getStartSeq: function() {
-    const start = (Math.max(0, Math.floor( this.g.zoomer.get('_alignmentScrollTop') / this.rectHeight))) + 1;
+    const alignmentScrollTop = this.isPinned ? 0 : this.g.zoomer.get('_alignmentScrollTop');
+    const start = (Math.max(0, Math.floor( alignmentScrollTop / this.rectHeight))) + 1;
     let counter = 0;
     let i = 0;
     while (counter < start && i < this.model.length) {
       counter += this.model.at(i).attributes.height || 1;
       i++;
     }
-    const y = Math.max(0, this.g.zoomer.get('_alignmentScrollTop') - counter * this.rectHeight + (this.model.at(i - 1)
+    const y = Math.max(0, alignmentScrollTop - counter * this.rectHeight + (this.model.at(i - 1)
     .attributes.height  || 1 ) * this.rectHeight);
     return [i - 1, -y];
   },
@@ -171,6 +172,7 @@ const CanvasSeqDrawer = function(g,ctx,model,opts) {
   this.height = opts.height;
   this.color = opts.color;
   this.cache = opts.cache;
+  this.isPinned = opts.isPinned;
   this.rectHeight = this.g.zoomer.get("rowHeight");
   this.rectWidth = this.g.zoomer.get("columnWidth"); // note: this can change
   return this;

--- a/src/views/header/HeaderBlock.js
+++ b/src/views/header/HeaderBlock.js
@@ -30,7 +30,8 @@ const View = boneView.extend({
   render: function() {
     this.renderSubviews();
 
-    return this.el.className = "biojs_msa_header";
+    this.el.style.height = (this.g.zoomer.get('rowHeight') * 3);
+    this.el.className = "biojs_msa_header";
   }
 });
 export default View;

--- a/src/views/header/HeaderBlock.js
+++ b/src/views/header/HeaderBlock.js
@@ -33,7 +33,7 @@ const View = boneView.extend({
     this.el.style.height = (
       15 +
       this.g.zoomer.get('rowHeight') * this.g.pinnedFeatures.getCurrentHeight()
-    );
+    ) + 'px';
     this.el.className = "biojs_msa_header";
   }
 });

--- a/src/views/header/HeaderBlock.js
+++ b/src/views/header/HeaderBlock.js
@@ -30,7 +30,10 @@ const View = boneView.extend({
   render: function() {
     this.renderSubviews();
 
-    this.el.style.height = (this.g.zoomer.get('rowHeight') * 3);
+    this.el.style.height = (
+      15 +
+      this.g.zoomer.get('rowHeight') * this.g.pinnedFeatures.getCurrentHeight()
+    );
     this.el.className = "biojs_msa_header";
   }
 });

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -29,13 +29,13 @@ const LabelHeader = view.extend({
       this.el.appendChild(this.metaDOM());
     }
 
-    this.el.style.display = "inline-block";
     this.el.style.fontSize = this.g.zoomer.get("markerFontsize");
     return this;
   },
 
   labelDOM: function() {
     var labelHeader = k.mk("div");
+    labelHeader.className = 'biojs_msa_header_label';
     labelHeader.style.width = this.g.zoomer.getLabelWidth();
     labelHeader.style.display = "inline-block";
 

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -35,17 +35,17 @@ const View = boneView.extend({
       },
     })));
 
-    const seqBlock = new SeqBlock({
-      model: this.model,
-      g: this.g,
-      el: document.createElement("canvas"),
-      isPinned: true,
-    });
-    // NOTE (pradeep): Hacky! Required for pinning the block
-    seqBlock.el.style.position = 'absolute';
-    seqBlock.el.style.bottom = 0;
+    // const seqBlock = new SeqBlock({
+    //   model: this.model,
+    //   g: this.g,
+    //   el: document.createElement("canvas"),
+    //   isPinned: true,
+    // });
+    // // NOTE (pradeep): Hacky! Required for pinning the block
+    // seqBlock.el.style.position = 'absolute';
+    // seqBlock.el.style.bottom = 0;
 
-    this.addView("pinnedSeqBlock", seqBlock);
+    // this.addView("pinnedSeqBlock", seqBlock);
 
     this.draw();
 

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -40,7 +40,6 @@ const View = boneView.extend({
       model: this.g.pinnedFeatures,
       g: this.g,
       el: document.createElement("canvas"),
-      isPinned: true,
     });
     // NOTE (pradeep): Hacky! Required for pinning the block
     pinnedBlock.el.style.position = 'absolute';

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -39,7 +39,6 @@ const View = boneView.extend({
     const pinnedBlock = new PinnedBlock({
       model: this.g.pinnedFeatures,
       g: this.g,
-      el: document.createElement("canvas"),
     });
     // NOTE (pradeep): Hacky! Required for pinning the block
     pinnedBlock.el.style.position = 'absolute';

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -4,6 +4,8 @@ import MarkerView from "./MarkerView";
 import ConservationView from "./ConservationView";
 import SeqLogoWrapper from "./SeqLogoWrapper";
 import GapView from "./GapView";
+import SeqBlock from "../canvas/CanvasSeqBlock";
+import { head } from "lodash";
 
 const View = boneView.extend({
 
@@ -25,44 +27,72 @@ const View = boneView.extend({
       return this.render();
     });
 
+    // collection view for all the headers
+    this.addView("headers", new (boneView.extend({
+      className: 'biojs_msa_rheaders',
+      events: { 
+        "scroll": () => this._sendScrollEvent(),
+      },
+    })));
+
+    const seqBlock = new SeqBlock({
+      model: this.model,
+      g: this.g,
+      el: document.createElement("canvas"),
+      isPinned: true,
+    });
+    // NOTE (pradeep): Hacky! Required for pinning the block
+    seqBlock.el.style.position = 'absolute';
+    seqBlock.el.style.bottom = 0;
+
+    this.addView("pinnedSeqBlock", seqBlock);
+
     this.draw();
 
     return this.g.vis.once('change:loaded', this._adjustScrollingLeft, this);
   },
 
-  events:
-    {"scroll": "_sendScrollEvent"},
+  _removeViews: function(...views) {
+    for (const view of views) {
+      if (this.getView(view)) {
+        this.removeView(view);
+      }
+    }
+  },
 
   draw: function() {
-    this.removeViews();
+    // this._removeViews('conserv', 'markers', 'seqlogo', 'gapHeader');
+    const headerView = this.getView('headers');
+    headerView.removeViews();
 
     if (this.g.vis.get("conserv")) {
       var conserv = new ConservationView({model: this.model, g: this.g});
       conserv.ordering = -20;
-      this.addView("conserv",conserv);
+      headerView.addView("conserv",conserv);
     }
 
     if (this.g.vis.get("markers")) {
       var marker = new MarkerView({model: this.model, g: this.g});
       marker.ordering = -10;
-      this.addView("marker",marker);
+      headerView.addView("marker",marker);
     }
 
     if (this.g.vis.get("seqlogo")) {
       var seqlogo = new SeqLogoWrapper({model: this.model, g: this.g});
       seqlogo.ordering = -30;
-      this.addView("seqlogo",seqlogo);
+      headerView.addView("seqlogo",seqlogo);
     }
 
     if (this.g.vis.get("gapHeader")) {
       var gapview = new GapView({model: this.model, g: this.g});
       gapview.ordering = -25;
-      return this.addView("gapview",gapview);
+      return headerView.addView("gapview",gapview);
     }
   },
 
   render: function() {
     this.renderSubviews();
+    this.getView('headers').renderSubviews();
 
     this._setSpacer();
 
@@ -76,7 +106,7 @@ const View = boneView.extend({
   // scrollLeft triggers a reflow of the whole area (even only get)
   _sendScrollEvent: function() {
     if (!this.blockEvents) {
-      this.g.zoomer.set("_alignmentScrollLeft", this.el.scrollLeft, {origin: "header"});
+      this.g.zoomer.set("_alignmentScrollLeft", this.getView('headers').el.scrollLeft, {origin: "header"});
     }
     return this.blockEvents = false;
   },
@@ -85,7 +115,10 @@ const View = boneView.extend({
     if ((!(((typeof options !== "undefined" && options !== null) ? options.origin : undefined) != null)) || options.origin !== "header") {
       var scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");
       this.blockEvents = true;
-      return this.el.scrollLeft = scrollLeft;
+      this.getView('headers').el.scrollLeft = scrollLeft;
+
+      // NOTE (pradeep): Hacky! Required for pinning the block by reverse translating parent's scroll offset
+      // this.getView('pinnedSeqBlock').el.style.left = -scrollLeft;
     }
   },
 

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -5,6 +5,7 @@ import ConservationView from "./ConservationView";
 import SeqLogoWrapper from "./SeqLogoWrapper";
 import GapView from "./GapView";
 import SeqBlock from "../canvas/CanvasSeqBlock";
+import PinnedBlock from "../canvas/CanvasPinnedBlock";
 import { head } from "lodash";
 
 const View = boneView.extend({
@@ -35,17 +36,17 @@ const View = boneView.extend({
       },
     })));
 
-    // const seqBlock = new SeqBlock({
-    //   model: this.model,
-    //   g: this.g,
-    //   el: document.createElement("canvas"),
-    //   isPinned: true,
-    // });
-    // // NOTE (pradeep): Hacky! Required for pinning the block
-    // seqBlock.el.style.position = 'absolute';
-    // seqBlock.el.style.bottom = 0;
+    const pinnedBlock = new PinnedBlock({
+      model: this.g.pinnedFeatures,
+      g: this.g,
+      el: document.createElement("canvas"),
+      isPinned: true,
+    });
+    // NOTE (pradeep): Hacky! Required for pinning the block
+    pinnedBlock.el.style.position = 'absolute';
+    pinnedBlock.el.style.bottom = 0;
 
-    // this.addView("pinnedSeqBlock", seqBlock);
+    this.addView("pinnedSeqBlock", pinnedBlock);
 
     this.draw();
 
@@ -118,7 +119,7 @@ const View = boneView.extend({
       this.getView('headers').el.scrollLeft = scrollLeft;
 
       // NOTE (pradeep): Hacky! Required for pinning the block by reverse translating parent's scroll offset
-      // this.getView('pinnedSeqBlock').el.style.left = -scrollLeft;
+      // this.getView('pinnedBlock').el.style.left = -scrollLeft;
     }
   },
 

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -51,16 +51,7 @@ const View = boneView.extend({
     return this.g.vis.once('change:loaded', this._adjustScrollingLeft, this);
   },
 
-  _removeViews: function(...views) {
-    for (const view of views) {
-      if (this.getView(view)) {
-        this.removeView(view);
-      }
-    }
-  },
-
   draw: function() {
-    // this._removeViews('conserv', 'markers', 'seqlogo', 'gapHeader');
     const headerView = this.getView('headers');
     headerView.removeViews();
 
@@ -115,9 +106,6 @@ const View = boneView.extend({
       var scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");
       this.blockEvents = true;
       this.getView('headers').el.scrollLeft = scrollLeft;
-
-      // NOTE (pradeep): Hacky! Required for pinning the block by reverse translating parent's scroll offset
-      // this.getView('pinnedBlock').el.style.left = -scrollLeft;
     }
   },
 

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -67,8 +67,6 @@ const View = boneView.extend({
     this._setSpacer();
 
     this.el.className = "biojs_msa_rheader";
-    this.el.style.overflowX = "auto";
-    this.el.style.display = "inline-block";
     //@el.style.height = @g.zoomer.get("markerHeight") + "px"
     this._setWidth();
     this._adjustScrollingLeft();


### PR DESCRIPTION
JIRA: SS-43581 (MSA Viewer: Support pinned annotations)

### Pinned annotations
This adds support for pinning annotations (known as `features` in the codebase).
The annotations get pinned to the top of the sequence canvas block and under the column number line, as shown below:

<img width="1178" alt="image" src="https://github.com/pradeepnschrodinger/msa/assets/41563608/861680fe-4345-4e19-853e-4ef7caeaa4fe">


### "HD" canvas
I've also made a util file (`src/utils/canvas.js`) for creating a hi-def canvas.
I then replaced the existing canvases used in sequence block rendering with the hi-def one, and this improved the quality pretty nicely in my system.
old:
<img width="992" alt="Screenshot 2023-09-02 at 7 20 32 AM" src="https://github.com/pradeepnschrodinger/msa/assets/41563608/2279ba2b-e67b-4a21-89a6-ecae62127536">
new:
<img width="983" alt="Screenshot 2023-09-02 at 7 20 49 AM" src="https://github.com/pradeepnschrodinger/msa/assets/41563608/a5008106-e181-40a6-91a4-7e969f2f1724">

