### PR TITLE
Allow user to specify layer order for pinned annotations

### DIFF
--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -72,6 +72,7 @@ const pinnedFeatures = [
         "feature": "gene",
         "start": 0,
         "end": 20,
+        "row": 1,
         "attributes": {
           "Name": "HFR1",
           "Color": "#E5FCDD",
@@ -82,6 +83,7 @@ const pinnedFeatures = [
     "feature": "gene",
     "start": 21,
     "end": 30,
+    "row": 1,
     "attributes": {
         "Name": "H1",
         "Color": "#E5FCDD",
@@ -92,6 +94,7 @@ const pinnedFeatures = [
     "feature": "gene",
     "start": 36,
     "end": 40,
+    "row": 1,
     "attributes": {
         "Name": "HFR2",
         "Color": "#E5FCDD",

--- a/src/model/FeatureCol.js
+++ b/src/model/FeatureCol.js
@@ -10,7 +10,6 @@ const FeatureCol = Collection.extend({
     this.startOnCache = [];
     // invalidate cache
     this.on( "all", (function() {
-      this.assignRows();
       return this.startOnCache = [];
     }), this);
     Collection.apply(this, arguments);


### PR DESCRIPTION
### Description:
This lets the user manually specify the layer order (row no:) for pinned annotations.
Previously, the annotations were auto packed by MSA into supposedly minimal no:of rows.

### Screenshot:
<img width="1195" alt="image" src="https://github.com/niaid/msa/assets/41563608/a0903455-12a4-457f-b3e5-7896fd11461b">