### PR TITLE
Fix annotations not scrolling when user does a mouse scroll

### DIFF
--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -17,10 +17,9 @@ const CanvasPinnedBlock = boneView.extend({
       this.g.zoomer, 
       "change:_alignmentScrollLeft change:_alignmentScrollTop change:alignmentWidth change:alignmentHeight", 
       function(model, value, options) {
-        if ((!(((typeof options !== "undefined" && options !== null) ? options.origin : undefined) != null)) || options.origin !== "canvasseq") {
-          return this.render();
-        }
-    });
+        return this.render();
+      }
+    );
   },
 
   adjustSize() {

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -117,6 +117,7 @@ const View = boneView.extend({
 
     events.mousewheel = "_onmousewheel";
     events.DOMMouseScroll = "_onmousewheel";
+    events.wheel = "_onmousewheel";
     this.delegateEvents(events);
 
     // listen for changes


### PR DESCRIPTION
JIRA: [SS-44736](https://jira.schrodinger.com/browse/SS-44736) (Sequence Viewer: Annotations does not scroll with mouse or click-drags)

The pinned canvas block which renders annotations was NOT scrolling when the user was doing a scroll either via the mouse or via clicking and dragging.

My first hunch was that we were not listening to certain scroll events.
But after debugging, it looks like we had some stale conditions that explicitly exited out of the scroll handler 🤦 .
Fixed it by removing them.