### PR TITLE
SS-45211: Allow custom font family to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ zoomer: {
     markerHeight: 20,
 
     // canvas
-    residueFont: "13", //in px
+    residueFont: "13px Helvetica Neue",
     canvasEventScale: 1,
 
     // overview box

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ zoomer: {
 
     // canvas
     residueFont: "13px Helvetica Neue",
+    residueFontOffset: [0, 0], // horizontal and vertical offset of residue font in px
     canvasEventScale: 1,
 
     // overview box

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -53,7 +53,7 @@ module.exports = Zoomer = Model.extend({
     markerHeight: 20,
 
     // canvas
-    residueFont: "13", // in px
+    residueFont: "13px Helvetica Neue", // in px
     canvasEventScale: 1,
     minLetterDrawSize: 11,
 

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -53,7 +53,8 @@ module.exports = Zoomer = Model.extend({
     markerHeight: 20,
 
     // canvas
-    residueFont: "13px Helvetica Neue", // in px
+    residueFont: "13px Helvetica Neue",
+    residueFontOffset: [0, 0], // horizontal and vertical offset of residue font in px
     canvasEventScale: 1,
     minLetterDrawSize: 11,
 

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -34,11 +34,12 @@ class CanvasCharCache {
     this.ctx = canvas.getContext('2d');
     canvas.adjustSize({ height, width })
     this.ctx.font = this.g.zoomer.get("residueFont");
+    const [xOffset, yOffset] = this.g.zoomer.get("residueFontOffset");
 
     this.ctx.textBaseline = 'middle';
     this.ctx.textAlign = "center";
 
-    return this.ctx.fillText(letter,width / 2,height / 2,width);
+    return this.ctx.fillText(letter, width / 2 + xOffset, height / 2 + yOffset, width);
   }
 };
 export default CanvasCharCache;

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -33,7 +33,7 @@ class CanvasCharCache {
     const canvas = this.cache[letter] = hdCanvas();
     this.ctx = canvas.getContext('2d');
     canvas.adjustSize({ height, width })
-    this.ctx.font = this.g.zoomer.get("residueFont") + "px mono";
+    this.ctx.font = this.g.zoomer.get("residueFont");
 
     this.ctx.textBaseline = 'middle';
     this.ctx.textAlign = "center";

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -41,7 +41,7 @@ const View = boneView.extend({
 
 
     // clear the char cache
-    this.listenTo(this.g.zoomer, "change:residueFont", function() {
+    this.listenTo(this.g.zoomer, "change:residueFont change:residueFontOffset", function() {
       this.cache = new CharCache(this.g);
       return this.render();
     });


### PR DESCRIPTION
MSA already supports a `residueFont` property, but this can only be used to set in the font size.

I'm making some small changes so that the user can pass in the entire font value, including font family.
eg: `residueFont: "13px Objective`

I'm also adding a new prop named `residueFontOffset` so that users can specify an offset for the font.
This is helpful for fonts like `Objective` where the font is slightly misaligned.