### PR TITLE
SS-45255: Remove empty spaces at the horizontal right end of the sequence block

### DIFF
--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -154,23 +154,17 @@ module.exports = Zoomer = Model.extend({
     if (this.g.config.get("shouldRenderSeqBlockAsSvg") === true) {
       val = calcWidth
     } else {
-      // This is to account for the margins/padding around the canvas's actual
-      // content area:
-      const marginAdjustment = 35;
       let parentWidth
       if ((this.el.parentNode != null) && this.el.parentNode.offsetWidth !== 0) {
-        parentWidth = this.el.parentNode.offsetWidth - marginAdjustment;
+        parentWidth = this.el.parentNode.offsetWidth;
       } else {
-        parentWidth = document.body.clientWidth - marginAdjustment;
+        parentWidth = document.body.clientWidth;
       }
 
       // TODO: dirty hack
       var maxWidth = parentWidth - this.getLeftBlockWidth();
       val = Math.min(maxWidth,calcWidth);
     }
-
-    // round to a valid AA box
-    val = Math.floor( val / this.get("columnWidth")) * this.get("columnWidth");
 
     //@set "alignmentWidth", val
     this.set("alignmentWidth", val)


### PR DESCRIPTION
JIRA: [SS-45255](https://jira.schrodinger.com/browse/SS-45255)
Primary: @karry08 

This removes extra empty spaces at the right end of the sequence block, giving more space for the viewer.

## Screenshots

Before:
<img width="1178" alt="Screenshot 2024-01-05 at 2 09 51 AM" src="https://github.com/pradeepnschrodinger/msa/assets/41563608/ad1c7c0d-2d83-4c47-8de2-6bf161bb7ceb">

After:
<img width="1177" alt="Screenshot 2024-01-05 at 2 09 37 AM" src="https://github.com/pradeepnschrodinger/msa/assets/41563608/6ef6a5e6-acfa-41f0-a2a7-9005fb2eb39e">