### PR TITLE
SS-44960: Fix scroll offsets not being updated when sequences change

### DIFF
--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -12,6 +12,8 @@ class ScrollBody {
 
     this.dragStart = [];
     this.dragStartScroll = [];
+
+    this._fixCurrentScroll();
   }
 
   getScrollEvents() {
@@ -173,6 +175,24 @@ class ScrollBody {
     }
 
     return scrollObj;
+  }
+
+  // Helper to fix the scrolling position
+  _fixCurrentScroll = () => {
+    const oldScrollLeft = this.g.zoomer.get('_alignmentScrollLeft');
+    const oldScrollTop = this.g.zoomer.get('_alignmentScrollTop');
+    const scrollCorrected = this._checkScrolling([
+      oldScrollLeft,
+      oldScrollTop
+    ]);
+
+    // only update if scroll values have changed
+    if (oldScrollLeft !== scrollCorrected[0]) {
+      this.g.zoomer.set('_alignmentScrollLeft', scrollCorrected[0]);
+    }
+    if (oldScrollTop !== scrollCorrected[1]) {
+      this.g.zoomer.set('_alignmentScrollTop', scrollCorrected[1]);
+    }
   }
 }
 

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -265,7 +265,7 @@ const View = boneView.extend({
   },
 
   _getResidueAtMouseEvent: function(e) {
-    const coords = mouse.rel(e);
+    const coords = mouse.rel(e.originalEvent);
 
     coords[0] += this.g.zoomer.get("_alignmentScrollLeft");
     let x = Math.floor(coords[0] / this.g.zoomer.get("columnWidth") );
@@ -286,7 +286,6 @@ const View = boneView.extend({
       const features = this.model.at(y).get("features").getFeatureOnRow(rowNumber - 1, x);
       if (!(features.length === 0)) {
         const feature = features[0];
-        console.log(features[0].attributes);
         return {seqId:seqId, feature: feature, rowPos: x, evt:e};
       }
     } else {

--- a/src/views/labels/LabelBlock.js
+++ b/src/views/labels/LabelBlock.js
@@ -1,10 +1,13 @@
 const boneView = require("backbone-childs");
 import LabelRowView from "./LabelRowView";
+import { defer } from "lodash";
 
 const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
+    this._adjustScrollingTop = this._adjustScrollingTop.bind(this);
+
     this.draw();
     this.listenTo(this.g.zoomer, "change:_alignmentScrollTop", this._adjustScrollingTop);
     this.g.vis.once('change:loaded', this._adjustScrollingTop , this);
@@ -22,7 +25,6 @@ const View = boneView.extend({
 
   draw: function() {
     this.removeViews();
-    console.log("redraw columns" , this.model.length);
     for (var i = 0; i < this.model.length; i++) {
         if (this.model.at(i).get('hidden')) { continue; }
         var view = new LabelRowView({model: this.model.at(i), g: this.g});
@@ -41,7 +43,7 @@ const View = boneView.extend({
 
   // sets the scrolling property (from another event e.g. dragging)
   _adjustScrollingTop() {
-    return this.el.scrollTop =  this.g.zoomer.get("_alignmentScrollTop");
+    this.el.scrollTop =  this.g.zoomer.get("_alignmentScrollTop");
   },
 
   render: function() {
@@ -55,6 +57,10 @@ const View = boneView.extend({
     this.el.style.lineHeight = `${this.g.zoomer.get("labelLineHeight")}`;
     this.el.style.width = 0 + this.g.zoomer.getLeftBlockWidth() + "px";
     this._setHeight();
+
+    // backbone JS has a delay with rendering the views into the DOM
+    defer(this._adjustScrollingTop);
+
     return this;
   },
 


### PR DESCRIPTION
JIRA: [SS-44960](https://jira.schrodinger.com/browse/SS-44960) (MSA Viewer: Sequences do not scroll with entity labels)
Primary: @karry08 

Previously, the scroll offsets for each view could go out of bounds when the data used by the view changed.
Similarly, when views were re-initialized (eg: Label view block), it's offset was also reset back to 0.

I added some code to clamp the scroll offsets within bounds during initialization, and fixed an edge case where the label view block's DOM element didn't get it's scroll offset updated in time.