### PR TITLE
Add render-stats module for debugging rendered stuff in canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,48 @@ menu: {
 }
 ```
 
+### Render Stats
+Information about the rendered content can be obtained by using the `renderStats` module, exposed in the global namespace (`msa.g`).
+This is useful incase devs wanna figure out what's actually rendered within the canvas.
+eg:
+```
+const renderStats = msa.g.renderStats.get()
+```
+gives
+```
+{
+    "sequenceBlock": {
+        "0": {
+            "monomers": [
+                "M",
+                "A",
+                "-",
+            ],
+            "colors": [
+                "#00ff00",
+                "#ccff00",
+                "#ffffff",
+            ]
+        },
+        "1": {
+            "monomers": [
+                "M",
+                "A",
+                "-",
+                "-",
+                "L"
+            ],
+            "colors": [
+                "#00ff00",
+                "#ccff00",
+                "#ffffff",
+                "#ffffff",
+                "#33ff00"
+            ]
+        },
+}
+```
+The above example shows 2 sequences of monomer lengths 3 and 5 respectively with their displayed monomer symbol and background color.
 FAQ
 ----
 

--- a/README.md
+++ b/README.md
@@ -510,6 +510,10 @@ const renderStats = msa.g.renderStats.get()
 gives
 ```
 {
+    "firstColumnIndex": 0,
+    "firstRowIndex": 0,
+    "lastColumnIndex": 4,
+    "lastRowIndex": 1,
     "sequenceBlock": {
         "0": {
             "monomers": [
@@ -539,9 +543,11 @@ gives
                 "#33ff00"
             ]
         },
+    },
 }
 ```
 The above example shows 2 sequences of monomer lengths 3 and 5 respectively with their displayed monomer symbol and background color.
+
 FAQ
 ----
 

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ gives
     "firstRowIndex": 0,
     "lastColumnIndex": 4,
     "lastRowIndex": 1,
-    "sequenceBlock": {
+    "renderedSequenceBlock": {
         "0": {
             "monomers": [
                 "M",

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -110,3 +110,5 @@ m.g.on("residue:hover", function(data){ console.log('residue:hover', data) });
 
 // BioJS event system test (you can safely remove this in your app)
 //instance=m.g
+
+window.m = m

--- a/src/msa.js
+++ b/src/msa.js
@@ -30,6 +30,7 @@ import FileHelper from "./utils/file";
 import TreeHelper from "./utils/tree";
 import ProxyHelper from "./utils/proxy";
 import FeatureCol from "./model/FeatureCol";
+import RenderStats from "./utils/renderStats";
 
 // opts is a dictionary consisting of
 // @param el [String] id or reference to a DOM element
@@ -67,6 +68,7 @@ const MSA = boneView.extend({
     this.g.vis = new Visibility(data.vis, {model: this.seqs});
     this.g.visorder = new VisOrdering(data.visorder);
     this.g.zoomer = new Zoomer(data.zoomer,{g:this.g, model: this.seqs});
+    this.g.renderStats = new RenderStats({ g: this.g, model: this.seqs });
 
     this.g.scale = new StageScale(data.scale, {g: this.g});
 

--- a/src/utils/renderStats.js
+++ b/src/utils/renderStats.js
@@ -1,0 +1,60 @@
+import _ from "lodash";
+
+class RenderStats {
+  constructor({ g, model }) {
+    this.g = g;
+    this.model = model;
+
+    this.clear();
+  }
+
+  clear() {
+    this.stats = {
+      renderedSequenceBlock: { },
+      firstRowIndex: null,
+      lastRowIndex: null,
+      firstColumnIndex: null,
+      lastColumnIndex: null,
+    }
+  }
+
+  get() {
+    return this.stats;
+  }
+
+  _getColor(color, { pos, y }) {
+    return this.g.colorscheme.getSelectedScheme().getColor(color, { 
+      pos, 
+      y,
+    });
+  }
+
+  _getOrCreateRenderedSequenceBlock(y) {
+    if (!this.stats.renderedSequenceBlock[y]) {
+      this.stats.renderedSequenceBlock[y] = {
+        monomers: [],
+        colors: [],
+      }
+    }
+
+    return this.stats.renderedSequenceBlock[y];
+  }
+
+  setRenderedMonomer = (monomerBlock) => {
+    const { x, y, c: color } = monomerBlock;
+
+    const block = this._getOrCreateRenderedSequenceBlock(y);
+    block.monomers.push(color);
+    block.colors.push(this._getColor(color, {
+      pos: x,
+      y: y,
+    }));
+
+    this.stats.firstRowIndex = _.min([this.stats.firstRowIndex, y]);
+    this.stats.lastRowIndex = _.max([this.stats.lastRowIndex, y]);
+    this.stats.firstColumnIndex = _.min([this.stats.firstColumnIndex, x]);
+    this.stats.lastColumnIndex = _.max([this.stats.lastColumnIndex, x]);
+  }
+}
+
+export default RenderStats;

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -178,7 +178,7 @@ const View = boneView.extend({
     const height = this.getPlannedElHeight();
 
     if (this.g.config.get("shouldRenderSeqBlockAsSvg") === true) {
-      this.el.setAttributeNS("http://www.w3.org/2000/svg", 'height', this.getPlannedElHeight());
+      this.el.setAttributeNS("http://www.w3.org/2000/svg", 'height', height);
       this.el.setAttributeNS("http://www.w3.org/2000/svg", 'width', width);
       this.el.style.width = `${width}px`;
       this.el.style.height = `${height}px`;

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -39,7 +39,6 @@ const View = boneView.extend({
 
     this.cache = new CharCache(this.g);
 
-
     // clear the char cache
     this.listenTo(this.g.zoomer, "change:residueFont change:residueFontOffset", function() {
       this.cache = new CharCache(this.g);
@@ -175,29 +174,30 @@ const View = boneView.extend({
   },
 
   render: function() {
+    const width = this.getPlannedElWidth();
+    const height = this.getPlannedElHeight();
+
     if (this.g.config.get("shouldRenderSeqBlockAsSvg") === true) {
       this.el.setAttributeNS("http://www.w3.org/2000/svg", 'height', this.getPlannedElHeight());
-      this.el.setAttributeNS("http://www.w3.org/2000/svg", 'width', this.getPlannedElWidth());
-      this.el.style.width = `${this.getPlannedElWidth()}px`;
-      this.el.style.height = `${this.getPlannedElHeight()}px`;
+      this.el.setAttributeNS("http://www.w3.org/2000/svg", 'width', width);
+      this.el.style.width = `${width}px`;
+      this.el.style.height = `${height}px`;
     } else {
       this.el.adjustSize({
-        height: this.getPlannedElHeight(),
-        width: this.getPlannedElWidth(),
+        height,
+        width,
       })
     }
 
     if (this.g.config.get("shouldRenderSeqBlockAsSvg") === true) {
-      const width = this.getPlannedElWidth();
-      const height = this.getPlannedElHeight();
       this.ctx = new C2S(width, height)
     }
 
     this._setColor();
 
     this.seqDrawer = new CanvasSeqDrawer( this.g,this.ctx,this.model, {
-      width: this.el.width,
-      height: this.el.height,
+      width,
+      height,
       color: this.color,
       cache: this.cache,
     });

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -1,4 +1,5 @@
 import {extend} from "lodash";
+import RenderStats from "../../utils/renderStats";
 
 const Drawer = {
 
@@ -9,6 +10,8 @@ const Drawer = {
   },
 
   drawLetters: function() {
+    // clear the stats every frame
+    this.g.renderStats.clear();
 
     this.updateConfig();
 
@@ -21,6 +24,12 @@ const Drawer = {
     if ( this.rectWidth >= this.g.zoomer.get('minLetterDrawSize')) {
       this.drawSeqs(function(data) { return this.drawSeq(data, this._drawLetter); });
     }
+
+    // record monomers rendered for this frame
+    const startTime = performance.now();
+    this.drawSeqs(function(data) { return this.drawSeq(data, (that, monomerBlock) => this.g.renderStats.setRenderedMonomer(monomerBlock)); });
+    console.log("stats: ", this.g.renderStats.get());
+    console.log("Time taken for stats", performance.now() - startTime, "ms")
 
     return this;
   },
@@ -161,7 +170,7 @@ const Drawer = {
     } else {
       return that.ctx.drawImage( that.cache.getFontTile(data.c, data.rectWidth, data.rectHeight, data.x, data.y), data.xPos, data.yPos, data.rectWidth, data.rectHeight);
     }
-  }
+  },
 };
 
 const CanvasSeqDrawer = function(g,ctx,model,opts) {

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -26,10 +26,7 @@ const Drawer = {
     }
 
     // record monomers rendered for this frame
-    const startTime = performance.now();
     this.drawSeqs(function(data) { return this.drawSeq(data, (that, monomerBlock) => this.g.renderStats.setRenderedMonomer(monomerBlock)); });
-    console.log("stats: ", this.g.renderStats.get());
-    console.log("Time taken for stats", performance.now() - startTime, "ms")
 
     return this;
   },


### PR DESCRIPTION
JIRA: [SS-46602](https://schrodinger.atlassian.net/browse/SS-46602) (Sequence Viewer: Come up with a method to verify sequence blocks in MSV)
Primary: @karry08 

### Description
Information about the rendered content can be obtained by using the `renderStats` module, exposed in the global namespace (`msa.g`).
This is useful incase devs wanna figure out what's actually rendered within the canvas.

### Example
```
const renderStats = msa.g.renderStats.get()
```
gives
```
{
    "firstColumnIndex": 0,
    "firstRowIndex": 0,
    "lastColumnIndex": 4,
    "lastRowIndex": 1,
    "renderedSequenceBlock": {
        "0": {
            "monomers": [
                "M",
                "A",
                "-",
            ],
            "colors": [
                "#00ff00",
                "#ccff00",
                "#ffffff",
            ]
        },
        "1": {
            "monomers": [
                "M",
                "A",
                "-",
                "-",
                "L"
            ],
            "colors": [
                "#00ff00",
                "#ccff00",
                "#ffffff",
                "#ffffff",
                "#33ff00"
            ]
        },
}
```
The above example shows 2 sequences of monomer lengths 3 and 5 respectively with their displayed monomer symbol and background color.
It also gives the starting and ending indices for both the visible rows and columns.

### Why
QA is gonna use this method in Selenium Tests once we figure out a way to abstract and expose the `renderStats` module inside Sequence Viewer.