### PR TITLE
SS-45431: Sequence Viewer: Click persists when cursor goes outside the iframe during a drag-scroll

### DIFF
--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -62,7 +62,7 @@ class ScrollBody {
     this.dragStart = mouse.abs(e.originalEvent);
     this.dragStartScroll = [this.g.zoomer.get('_alignmentScrollLeft'), this.g.zoomer.get('_alignmentScrollTop')];
     jbone(document.body).on('mousemove.overmove', (e) => this._onmousedrag(e));
-    jbone(document.body).on('mouseup.overup', () => this._cleanup());
+    jbone(window).on('mouseup.overup', () => this._cleanup());
     //jbone(document.body).on 'mouseout.overout', (e) => @_onmousewinout(e)
     return e.preventDefault();
   }


### PR DESCRIPTION
Issue: mouseUp event is not captured outside the msa document body.
So suppose while dragging on sequence viewer for horizontally scrollable sequences, user go outside of iframe and release the mouse then there is no cleanup function triggered to disable dragging action .When user move pointer again inside the iframe the sequence will start dragging .

Workaround: Capture the mouseUp event for the whole window .So wherever the user release the mouse the cleanup function will be triggered which will further remove all the listeners and terminates dragging.

Primary: @karry08 