### PR TITLE
SS-45571: Sequence Viewer: Pop-out mode doesn't display any sequence

### DIFF
--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -164,7 +164,7 @@ module.exports = Zoomer = Model.extend({
       }
 
       // TODO: dirty hack
-      var maxWidth = parentWidth - this.getLeftBlockWidth();
+      var maxWidth = Math.max(parentWidth - this.getLeftBlockWidth(), 0);
       val = Math.min(maxWidth,calcWidth);
     }
 


### PR DESCRIPTION
Jira: https://schrodinger.atlassian.net/browse/SS-45571
In some case maxWidth was becoming less than 0, which caused the sequences to not be displayed. Specifically, when we open sequence viewer in a popout and then try to open MSV, it was blank.
Making sure maxWidth never goes below 0.

Primary: @pradeepnschrodinger 