### PR TITLE
Specify border and seperator colors for pinned annotations

### DIFF
--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -63,6 +63,12 @@ const pinnedFeatures = [
       "feature": "gene",
       "start": 0,
       "end": 100,
+      "topBorderColor": "red",
+      "topBorderWidth": 3,
+      "verticalSeperatorColor": "blue",
+      "verticalSeperatorWidth": 5,
+      "bottomBorderColor": "black",
+      "bottomBorderWidth": 1,
       "attributes": {
           "Name": "VH",
           "Color": "#E5FCDD",

--- a/snippets/fer1_annoted.js
+++ b/snippets/fer1_annoted.js
@@ -63,15 +63,15 @@ const pinnedFeatures = [
       "feature": "gene",
       "start": 0,
       "end": 100,
-      "topBorderColor": "red",
+      "topBorderColor": "#999999",
       "topBorderWidth": 3,
-      "verticalSeperatorColor": "blue",
-      "verticalSeperatorWidth": 5,
+      "verticalSeperatorColor": "#808080",
+      "verticalSeperatorWidth": 1,
       "bottomBorderColor": "black",
       "bottomBorderWidth": 1,
       "attributes": {
           "Name": "VH",
-          "Color": "#E5FCDD",
+          "Color": "#E5E5E5",
           "textColor": "#71B567",
         }
       },
@@ -82,7 +82,7 @@ const pinnedFeatures = [
         "row": 1,
         "attributes": {
           "Name": "HFR1",
-          "Color": "#E5FCDD",
+          "Color": "#F0F0F0",
           "textColor": "#71B567",
     }
   },
@@ -93,7 +93,7 @@ const pinnedFeatures = [
     "row": 1,
     "attributes": {
         "Name": "H1",
-        "Color": "#E5FCDD",
+        "Color": "#F8F8F8",
         "textColor": "#71B567",
     }
   },
@@ -104,7 +104,7 @@ const pinnedFeatures = [
     "row": 1,
     "attributes": {
         "Name": "HFR2",
-        "Color": "#E5FCDD",
+        "Color": "#F0F0F0",
         "textColor": "#71B567",
     }
   },

--- a/src/model/Feature.js
+++ b/src/model/Feature.js
@@ -12,6 +12,12 @@ const Feature = Model.extend({
     type: "rectangle",
     borderSize: 1,
     borderColor: "black",
+    verticalSeperatorColor: "black",
+    verticalSeperatorWidth: 1,
+    bottomBorderColor: "black",
+    bottomBorderWidth: 1,
+    topBorderColor: "black",
+    topBorderWidth: 1,
     borderOpacity: 0.5,
     validate: true,
     row: 0

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -51,13 +51,13 @@ const CanvasPinnedBlock = boneView.extend({
       this.ctx.fillStyle = feature.attributes.fillColor;
       this.ctx.fillRect(x + xOffset, y, width, height);
 
-      // draw vertical borders
+      // for vertical borders
       this.ctx.strokeStyle =
       feature.attributes.verticalSeperatorColor
       this.ctx.lineWidth =
         feature.attributes.verticalSeperatorWidth
 
-      // //draw left vertical border
+      // draw left vertical border
       this.ctx.beginPath();
       this.ctx.moveTo(x + xOffset, y);
       this.ctx.lineTo(x + xOffset, y + height);

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -51,14 +51,35 @@ const CanvasPinnedBlock = boneView.extend({
       this.ctx.fillStyle = feature.attributes.fillColor;
       this.ctx.fillRect(x + xOffset, y, width, height);
 
-      // draw background block border
-      this.ctx.strokeStyle = feature.attributes.verticalSeperatorColor || '#808080';
-      this.ctx.lineWidth = feature.attributes.verticalSeperatorWidth || borderWidth;
-      this.ctx.strokeRect(x + xOffset, y, width, height);
-      
+      // draw vertical borders
+      this.ctx.strokeStyle =
+      feature.attributes.verticalSeperatorColor
+      this.ctx.lineWidth =
+        feature.attributes.verticalSeperatorWidth
+
+      // //draw left vertical border
+      this.ctx.beginPath();
+      this.ctx.moveTo(x + xOffset, y);
+      this.ctx.lineTo(x + xOffset, y + height);
+      this.ctx.stroke();
+
+      //draw right vertical border
+      this.ctx.beginPath();
+      this.ctx.moveTo(x + xOffset + width, y);
+      this.ctx.lineTo(x + xOffset + width, y + height);
+      this.ctx.stroke();
+
+      //draw bottom border
+      this.ctx.strokeStyle = feature.attributes.bottomBorderColor
+      this.ctx.lineWidth = feature.attributes.bottomBorderWidth
+      this.ctx.beginPath();
+      this.ctx.moveTo(x + xOffset, y + height);
+      this.ctx.lineTo(x + xOffset + width, y + height);
+      this.ctx.stroke();
+
       // draw top border
-      this.ctx.strokeStyle = feature.attributes.topBorderColor || '#999999'; // Default to #999999 if not specified
-      this.ctx.lineWidth = feature.attributes.topBorderWidth || 1; // Default to 1 if not specified
+      this.ctx.strokeStyle = feature.attributes.topBorderColor 
+      this.ctx.lineWidth = feature.attributes.topBorderWidth
       this.ctx.beginPath();
       this.ctx.moveTo(x + xOffset, y);
       this.ctx.lineTo(x + xOffset + width, y);

--- a/src/views/canvas/CanvasPinnedBlock.js
+++ b/src/views/canvas/CanvasPinnedBlock.js
@@ -36,7 +36,7 @@ const CanvasPinnedBlock = boneView.extend({
   drawFeatures() {
     const rectWidth = this.g.zoomer.get("columnWidth");
     const rectHeight = this.g.zoomer.get("rowHeight");
-    const borderWidth = 0.75;
+    const borderWidth = 1;
     const xOffset = this.getXOffset(rectWidth);
 
     // TODO (pradeep): Perform virtualization here?
@@ -52,9 +52,17 @@ const CanvasPinnedBlock = boneView.extend({
       this.ctx.fillRect(x + xOffset, y, width, height);
 
       // draw background block border
-      this.ctx.strokeStyle = 'black';
-      this.ctx.lineWidth = borderWidth;
+      this.ctx.strokeStyle = feature.attributes.verticalSeperatorColor || '#808080';
+      this.ctx.lineWidth = feature.attributes.verticalSeperatorWidth || borderWidth;
       this.ctx.strokeRect(x + xOffset, y, width, height);
+      
+      // draw top border
+      this.ctx.strokeStyle = feature.attributes.topBorderColor || '#999999'; // Default to #999999 if not specified
+      this.ctx.lineWidth = feature.attributes.topBorderWidth || 1; // Default to 1 if not specified
+      this.ctx.beginPath();
+      this.ctx.moveTo(x + xOffset, y);
+      this.ctx.lineTo(x + xOffset + width, y);
+      this.ctx.stroke();
 
       // draw text
       this.ctx.fillStyle = feature.attributes.textColor || "black";


### PR DESCRIPTION
JIRA: [SS-44505](https://schrodinger.atlassian.net/browse/SS-44504) (Sequence Viewer: The Framework Regions(FRs) are not coloured in grey)

These changes are made for adding the support in MSA to change the top border colour, top border width, vertical seperator colour, vertical seperator width, bottom border colour and it's width. The PR for corresponding changes in sequence viewer - https://github.com/schrodinger/livedesign-gadgets/pull/2142

Updated the fer1_annotted.js example for the same. The uppermost layer which is VH is set with different colours and widths of the top border, vertical seperator and bottom border.
PFA screenshot : 

<img width="1512" alt="Screenshot 2024-05-30 at 6 19 30 PM" src="https://github.com/pradeepnschrodinger/msa/assets/136438775/0415b4d8-9b37-4444-9968-f03a039ba544">
