### PR TITLE
LDTOOLS-142: MSA Viewer: Improve selection behavior and provide APIs to get and set selection data

### DIFF
--- a/css/msa.css
+++ b/css/msa.css
@@ -27,6 +27,9 @@
     text-align: left;
 
     text-overflow: ellipsis;
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none; /* Standard syntax */
 }
 
 .biojs_msa_header {

--- a/src/g/selection/Selection.js
+++ b/src/g/selection/Selection.js
@@ -57,7 +57,23 @@ const PosSelection = RowSelection.extend(extend( {},
   })
 }));
 
+const LabelSelection = Selection.extend({
+  defaults: extend( {}, Selection.prototype.defaults,
+    {type: "label",
+    seqId: ""
+  }),
+
+  inRow() {
+    return false;
+  },
+
+  inColumn() {
+    return false;
+  },
+});
+
 export {Selection as sel};
 export {PosSelection as possel};
 export {RowSelection as rowsel};
 export {ColumnSelection as columnsel};
+export {LabelSelection as labelsel};

--- a/src/g/selection/Selection.js
+++ b/src/g/selection/Selection.js
@@ -7,6 +7,8 @@ const Selection = Model.extend({
     {type: "super"}
 });
 
+// inRow and inColumn functions are used to determine if a model is in a particular row or column
+
 const RowSelection = Selection.extend({
   defaults: extend( {}, Selection.prototype.defaults,
     {type: "row",
@@ -17,6 +19,7 @@ const RowSelection = Selection.extend({
     return seqId === this.get("seqId");
   },
 
+  // a row selection is in every column
   inColumn(rowPos) {
     return true;
   },
@@ -33,6 +36,7 @@ const ColumnSelection = Selection.extend({
     xEnd: -1
   }),
 
+  // a column selection is in every row
   inRow() {
     return true;
   },
@@ -63,6 +67,8 @@ const LabelSelection = Selection.extend({
     seqId: ""
   }),
 
+  // a label selection is a different model type and has no meaning of being in a row or column
+  // so inRow() and inColumn() always return false
   inRow() {
     return false;
   },

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -223,7 +223,7 @@ const SelectionManager = Collection.extend({
     if (e.ctrlKey || e.metaKey) {
       this._updateLastSelection(selection);
       if (this._isAlreadySelected(selection, this.models)) {
-        this.remove(this._modelsToRemove(selection, this.models))
+        this.remove(this._modelsToRemove(selection, this.models));
       } else {
         this._addSelection(selection);
       }
@@ -253,20 +253,32 @@ const SelectionManager = Collection.extend({
 
   _resetSelection: function(selection) {
     if (selection.get("type") === "row") {
-      selection = [selection, new labelsel({seqId: selection.get("seqId")})]
+      selection = [selection, new labelsel({seqId: selection.get("seqId")})];
     }
     this.reset(selection);
+  },
+
+  _isSelectionValid: function(selection) {
+    const seqId = selection.get("seqId");
+    const xStart = selection.get("xStart");
+    const xEnd = selection.get("xEnd");
+
+    return _.some(this.g.seqs.models, (model) => 
+      (!seqId || model.attributes.id === seqId) && 
+      (!xStart || xStart >= 0) && 
+      (!xEnd || xEnd < model.attributes.seq.length)
+    );
   },
   
 
   _handleShiftSelection: function(selection) {
-    const seqIdToIdxMap = this.g.seqs.models.reduce((acc, model, idx) => {
+    const seqIdToIdxMap = _.reduce(this.g.seqs.models, (acc, model, idx) => {
       const { id } = model.attributes
       acc[id] = idx
       return acc
     }, {});
 
-    const idxToSeqIdMap = this.g.seqs.models.reduce((acc, model, idx) => {
+    const idxToSeqIdMap = _.reduce(this.g.seqs.models, (acc, model, idx) => {
       const { id } = model.attributes
       acc[idx] = id
       return acc
@@ -275,110 +287,110 @@ const SelectionManager = Collection.extend({
     const lastSelection = this.lastSelection;
     this._updateLastSelection(selection);
 
-    if (!lastSelection) {
+    if (!lastSelection || !this._isSelectionValid(lastSelection)) {
       this._addSelection(selection);
       return;
     }
 
-    const lastSelectionType = lastSelection.get("type")
-    const lSelSeqIdIdx = seqIdToIdxMap[lastSelection.get("seqId")]
-    const lSelXStart = lastSelection.get("xStart")
-    const lSelXEnd = lastSelection.get("xEnd")
+    const lastSelectionType = lastSelection.get("type");
+    const lSelSeqIdIdx = seqIdToIdxMap[lastSelection.get("seqId")];
+    const lSelXStart = lastSelection.get("xStart");
+    const lSelXEnd = lastSelection.get("xEnd");
 
-    const selectionType = selection.get("type")
-    const selSeqIdIdx = seqIdToIdxMap[selection.get("seqId")]
-    const selXStart = selection.get("xStart")
-    const selXEnd = selection.get("xEnd")
+    const selectionType = selection.get("type");
+    const selSeqIdIdx = seqIdToIdxMap[selection.get("seqId")];
+    const selXStart = selection.get("xStart");
+    const selXEnd = selection.get("xEnd");
 
-    const minXStart = Math.min(lSelXStart, selXStart)
-    const maxXEnd = Math.max(lSelXEnd, selXEnd)
-    const minSeqIdIdx = Math.min(lSelSeqIdIdx, selSeqIdIdx)
-    const maxSeqIdIdx = Math.max(lSelSeqIdIdx, selSeqIdIdx)
+    const minXStart = Math.min(lSelXStart, selXStart);
+    const maxXEnd = Math.max(lSelXEnd, selXEnd);
+    const minSeqIdIdx = Math.min(lSelSeqIdIdx, selSeqIdIdx);
+    const maxSeqIdIdx = Math.max(lSelSeqIdIdx, selSeqIdIdx);
 
     if (lastSelectionType === "row" && selectionType === "row") {
       // Select all rows between the last selection and the current selection
-      const selections = []
+      const selections = [];
       for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
-        selections.push(new rowsel({seqId: idxToSeqIdMap[i]}))
+        selections.push(new rowsel({seqId: idxToSeqIdMap[i]}));
       }
-      this._addSelection(selections)
+      this._addSelection(selections);
     } else if (lastSelectionType === "column" && selectionType === "column") {
       // Select all columns between the last selection and the current selection
-      const columns = []
+      const columns = [];
       for (let i = minXStart; i <= maxXEnd; i++) {
-          columns.push(new columnsel({xStart: i, xEnd: i}))
+          columns.push(new columnsel({xStart: i, xEnd: i}));
       }
-      this._addSelection(columns)
+      this._addSelection(columns);
     } else if (lastSelectionType === "pos" && selectionType === "pos" ) {
       // Select all residues between the last selection and the current selection
-      const positions = []
+      const positions = [];
       for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
         for (let j = minXStart; j <= maxXEnd; j++) {
-          positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[i]}))
+          positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[i]}));
         }
       }
-      this._addSelection(positions)
+      this._addSelection(positions);
     } else if (lastSelectionType === "label" && selectionType === "label" ) {
       // Select all residues between the last selection and the current selection
-      const labels = []
+      const labels = [];
       for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
-        labels.push(new labelsel({seqId: idxToSeqIdMap[i]}))
+        labels.push(new labelsel({seqId: idxToSeqIdMap[i]}));
       }
-      this._addSelection(labels)
-    } else if (lastSelectionType === "row" && selectionType === "pos" || lastSelectionType === "pos" && selectionType === "row") {
-      const positions = []
+      this._addSelection(labels);
+    } else if (lastSelectionType === "row" && selectionType === "pos") {
+      const positions = [];
       for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
         for (let j = selXStart; j <= selXEnd; j++) {
-          positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[i]}))
+          positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[i]}));
         }
       }
-      this._addSelection(positions)
-    } else if (lastSelectionType === "column" && selectionType === "pos" || lastSelectionType === "pos" && selectionType === "column") {
-      const positions = []
+      this._addSelection(positions);
+    } else if (lastSelectionType === "column" && selectionType === "pos") {
+      const positions = [];
       for (let j = minXStart; j <= maxXEnd; j++) {
-        positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[selSeqIdIdx]}))
+        positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[selSeqIdIdx]}));
       }
-      this._addSelection(positions)
+      this._addSelection(positions);
     } else {
       // Select the current selection
-      this._addSelection(selection)
+      this._addSelection(selection);
     }
   },
 
   _isAlreadySelected: function(selection, models) {
-    const selectionType = selection.get("type")
-    const modelsOfType = models.filter(m => m.get("type") === selectionType)
+    const selectionType = selection.get("type");
+    const modelsOfType = models.filter(m => m.get("type") === selectionType);
     switch (selectionType) {
       case "row":
-        return modelsOfType.some(m => m.get("seqId") === selection.get("seqId"))
+        return modelsOfType.some(m => m.get("seqId") === selection.get("seqId"));
       case "label":
-        return modelsOfType.some(m => m.get("seqId") === selection.get("seqId"))
+        return modelsOfType.some(m => m.get("seqId") === selection.get("seqId"));
       case "column":
-        return modelsOfType.some(m => m.get("xStart") === selection.get("xStart") && m.get("xEnd") === selection.get("xEnd"))
+        return modelsOfType.some(m => m.get("xStart") === selection.get("xStart") && m.get("xEnd") === selection.get("xEnd"));
       case "pos":
-        return modelsOfType.some(m => m.get("xStart") === selection.get("xStart") && m.get("xEnd") === selection.get("xEnd") && m.get("seqId") === selection.get("seqId"))
+        return modelsOfType.some(m => m.get("xStart") === selection.get("xStart") && m.get("xEnd") === selection.get("xEnd") && m.get("seqId") === selection.get("seqId"));
       default:
-        return false
+        return false;
     }
   },
 
   _modelsToRemove: function(selection, models) {
-    const selectionType = selection.get("type")
+    const selectionType = selection.get("type");
     switch (selectionType) {
       case "row":
         // Remove all rowsel, labelsel, and possel with the same seqId
-        return models.filter(m => m.get("seqId") === selection.get("seqId"))
+        return models.filter(m => m.get("seqId") === selection.get("seqId"));
         // Remove only the labelsel with the same seqId
       case "label":
-        return models.filter(m => m.get("type") === "label" && m.get("seqId") === selection.get("seqId"))
+        return models.filter(m => m.get("type") === "label" && m.get("seqId") === selection.get("seqId"));
       case "column":
         // Remove all overlapping columnsel and possel
-        return models.filter(m => selection.get("xStart") <= m.get("xStart") && m.get("xEnd") <= selection.get("xEnd"))
+        return models.filter(m => selection.get("xStart") <= m.get("xStart") && m.get("xEnd") <= selection.get("xEnd"));
       case "pos":
         // Remove all overlapping possel
-        return models.filter(m => selection.get("xStart") <= m.get("xStart") && m.get("xEnd") <= selection.get("xEnd") && m.get("seqId") === selection.get("seqId"))
+        return models.filter(m => selection.get("xStart") <= m.get("xStart") && m.get("xEnd") <= selection.get("xEnd") && m.get("seqId") === selection.get("seqId"));
       default:
-        return []
+        return [];
     }
   },
 

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -266,7 +266,7 @@ const SelectionManager = Collection.extend({
           const { xStart, seqId, xEnd } = model.attributes;
           for (let j = xStart; j <= xEnd; j++) {
             if (!selectedPositionsSet.has(`${seqId}-${j}`)) {
-              selectionData.selectedPositions.push({ seqId: seqId, columnIdx: j });
+              selectionData.selectedPositions.push({ seqId: seqId, columnIndex: j });
               selectedPositionsSet.add(`${seqId}-${j}`);
             }
           }
@@ -299,8 +299,8 @@ const SelectionManager = Collection.extend({
       models.push(new columnsel({xStart, xEnd: xStart}));
     });
 
-    selectionData.selectedPositions.forEach(({ seqId, columnIdx }) => {
-      models.push(new possel({xStart: columnIdx, xEnd: columnIdx, seqId}));
+    selectionData.selectedPositions.forEach(({ seqId, columnIndex }) => {
+      models.push(new possel({xStart: columnIndex, xEnd: columnIndex, seqId}));
     });
 
     selectionData.selectedLabels.forEach((seqId) => {

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -342,6 +342,14 @@ const SelectionManager = Collection.extend({
     this.reset(models, {silent});
   },
 
+  _refineSelections: function() {
+    // 1. Refine selections to remove any overlapping selections.
+    // 2. Convert pos selections to row or column selections, if possible.
+    // 2. Reduce contiguous column or position selections to groups of individual column or position selections.
+    const selectionData = this.getSelectionData();
+    this.setSelectionData(selectionData);
+  },
+
   _handleE: function(e, selection) {
     if (e.ctrlKey || e.metaKey) {
       if (this._isAlreadySelected(selection)) {
@@ -356,11 +364,8 @@ const SelectionManager = Collection.extend({
       this._updateSelections([selection], "reset", true);
     }
 
+    this._refineSelections();
     this._updateLastSelection(selection);
-    // Refine the selection to remove any overlapping selections (convert pos selections to row or column selections if possible) 
-    // and reduce contiguous columns or positions to groups of individual column or position selections
-    const selectionData = this.getSelectionData();
-    this.setSelectionData(selectionData);
   },
 
   _updateSelections: function(selectionArr, updateType, silent = false) {

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -305,20 +305,26 @@ const SelectionManager = Collection.extend({
 
   setSelectionData: function(selectionData, silent = false) {
     const sequences = this._getSequences();
+    const filteredSelectionData = _.pickBy(selectionData, (_data, seqId) => sequences[seqId]);
+    if (_.isEmpty(filteredSelectionData)) {
+      this.reset([], {silent});
+      return;
+    }
+
     const models = [];
     const completelySelectedRows = [];
-
     _.forEach(sequences, (sequence) => {
-      if (selectionData[sequence.id] && selectionData[sequence.id].selectedResidues.length === sequence.seq.length) {
+      if (filteredSelectionData[sequence.id].selectedResidues.length === sequence.seq?.length) {
         completelySelectedRows.push(sequence.id);
       }
     });
 
     let completelySelectedColumns = [];
-    if (_.keys(sequences).length === _.keys(selectionData).length) {
-      completelySelectedColumns = _.intersection(..._.map(selectionData, (data) => data.selectedResidues));
+    if (_.keys(sequences).length === _.keys(filteredSelectionData).length) {
+      completelySelectedColumns = _.intersection(..._.map(filteredSelectionData, (data) => data.selectedResidues));
     }
-    const partiallySelectedRows = _.omit(selectionData, completelySelectedRows);
+
+    const partiallySelectedRows = _.omit(filteredSelectionData, completelySelectedRows);
 
     completelySelectedRows.forEach((seqId) => {
       models.push(new rowsel({ seqId }));
@@ -341,7 +347,7 @@ const SelectionManager = Collection.extend({
         }
       });
     })
-    const selectedEntities = _.keys(selectionData).filter(key => selectionData[key].isLabelSelected);
+    const selectedEntities = _.keys(filteredSelectionData).filter(key => filteredSelectionData[key].isLabelSelected);
     selectedEntities.forEach((seqId) => {
       models.push(new labelsel({ seqId: sequences[seqId].id }));
     });

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -468,7 +468,13 @@ const SelectionManager = Collection.extend({
   },
 
   _isAlreadySelected: function(selection) {
-    // models are refined selections - we need to check if the selection is already present in the models
+    // Models in the collection are refined selections
+    // To check if a selection is already selected, we need to check the following:
+    // 1) For row selections, check if there is a row model with the same seqId
+    // 2) For label selections, check if there is a label model with the same seqId
+    // 3) For column selections, check if there are column models for each value from xStart to xEnd of selection
+    // 4) For position selections, check if the entire row with same seqId is selected. If not, check if there are position or column models for each value from xStart to xEnd of selection
+
     const selectionType = selection.get("type");
     switch (selectionType) {
       case "row":
@@ -505,6 +511,15 @@ const SelectionManager = Collection.extend({
   },
 
   _deselectSelection: function(selection) {
+    // Since the selections are refined, de-selection should be done in the following way:
+    // 1) For row de-selections, remove all row, label and position models with the same seqId
+    // 2) For label de-selections, remove all label models with the same seqId
+    // 3) For column de-selections, remove all column models with xStart and xEnd between the xStart and xEnd of selection
+    // 4) For position de-selections, there can be 3 cases:
+    //    a) If the complete row is selected, remove the row selection and add remaining positions for that row
+    //    b) If the complete column is selected, remove the column selection and add remaining positions for that column. Do this for all columns in the selection.
+    //    c) Remove the position selections between xStart and xEnd of selection
+
     const selectionType = selection.get("type");
     const sequences = this._getSequences();
     switch (selectionType) {

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -288,6 +288,7 @@ const SelectionManager = Collection.extend({
       selectedLabels: Array.from(selectionData.selectedLabels),
     };
   },
+
   // @param silent [Boolean] if true, no events are triggered for the collection update
   setSelectionData: function(selectionData, silent = false) {
     const models = [];
@@ -351,7 +352,6 @@ const SelectionManager = Collection.extend({
     );
   },
   
-
   _handleShiftSelection: function(selection) {
     const seqIdToIdxMap = _.reduce(this.g.seqs.models, (acc, model, idx) => {
       const { id } = model.attributes
@@ -418,7 +418,8 @@ const SelectionManager = Collection.extend({
       }
       this.add(labels, {silent: true});
     } else if (lastSelectionType === "row" && selectionType === "pos") {
-      // 
+      // Select all residues between the last row selection and the current position selection.
+      // Use column indices from the position selection.
       const positions = [];
       for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
         for (let j = selXStart; j <= selXEnd; j++) {
@@ -427,7 +428,7 @@ const SelectionManager = Collection.extend({
       }
       this.add(positions, {silent: true});
     } else if (lastSelectionType === "column" && selectionType === "pos") {
-      //
+      // Select all residues between the last column selection and the current position selection, using the seqId from the position selection
       const positions = [];
       for (let j = minXStart; j <= maxXEnd; j++) {
         positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[selSeqIdIdx]}));

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -260,6 +260,18 @@ const SelectionManager = Collection.extend({
   
 
   _handleShiftSelection: function(selection) {
+    const seqIdToIdxMap = this.g.seqs.models.reduce((acc, model, idx) => {
+      const { id } = model.attributes
+      acc[id] = idx
+      return acc
+    }, {});
+
+    const idxToSeqIdMap = this.g.seqs.models.reduce((acc, model, idx) => {
+      const { id } = model.attributes
+      acc[idx] = id
+      return acc
+    }, {});
+
     const lastSelection = this.lastSelection;
     this._updateLastSelection(selection);
 
@@ -269,25 +281,25 @@ const SelectionManager = Collection.extend({
     }
 
     const lastSelectionType = lastSelection.get("type")
-    const lSelSeqId = lastSelection.get("seqId")
+    const lSelSeqIdIdx = seqIdToIdxMap[lastSelection.get("seqId")]
     const lSelXStart = lastSelection.get("xStart")
     const lSelXEnd = lastSelection.get("xEnd")
 
     const selectionType = selection.get("type")
-    const selSeqId = selection.get("seqId")
+    const selSeqIdIdx = seqIdToIdxMap[selection.get("seqId")]
     const selXStart = selection.get("xStart")
     const selXEnd = selection.get("xEnd")
 
     const minXStart = Math.min(lSelXStart, selXStart)
     const maxXEnd = Math.max(lSelXEnd, selXEnd)
-    const minSeqId = Math.min(lSelSeqId, selSeqId)
-    const maxSeqId = Math.max(lSelSeqId, selSeqId)
+    const minSeqIdIdx = Math.min(lSelSeqIdIdx, selSeqIdIdx)
+    const maxSeqIdIdx = Math.max(lSelSeqIdIdx, selSeqIdIdx)
 
     if (lastSelectionType === "row" && selectionType === "row") {
       // Select all rows between the last selection and the current selection
       const selections = []
-      for (let i = minSeqId; i <= maxSeqId; i++) {
-        selections.push(new rowsel({seqId: i}))
+      for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
+        selections.push(new rowsel({seqId: idxToSeqIdMap[i]}))
       }
       this._addSelection(selections)
     } else if (lastSelectionType === "column" && selectionType === "column") {
@@ -300,31 +312,31 @@ const SelectionManager = Collection.extend({
     } else if (lastSelectionType === "pos" && selectionType === "pos" ) {
       // Select all residues between the last selection and the current selection
       const positions = []
-      for (let i = minSeqId; i <= maxSeqId; i++) {
+      for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
         for (let j = minXStart; j <= maxXEnd; j++) {
-          positions.push(new possel({xStart: j, xEnd: j, seqId: i}))
+          positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[i]}))
         }
       }
       this._addSelection(positions)
     } else if (lastSelectionType === "label" && selectionType === "label" ) {
       // Select all residues between the last selection and the current selection
       const labels = []
-      for (let i = minSeqId; i <= maxSeqId; i++) {
-        labels.push(new labelsel({seqId: i}))
+      for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
+        labels.push(new labelsel({seqId: idxToSeqIdMap[i]}))
       }
       this._addSelection(labels)
     } else if (lastSelectionType === "row" && selectionType === "pos" || lastSelectionType === "pos" && selectionType === "row") {
       const positions = []
-      for (let i = minSeqId; i <= maxSeqId; i++) {
+      for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
         for (let j = selXStart; j <= selXEnd; j++) {
-          positions.push(new possel({xStart: j, xEnd: j, seqId: i}))
+          positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[i]}))
         }
       }
       this._addSelection(positions)
     } else if (lastSelectionType === "column" && selectionType === "pos" || lastSelectionType === "pos" && selectionType === "column") {
       const positions = []
       for (let j = minXStart; j <= maxXEnd; j++) {
-        positions.push(new possel({xStart: j, xEnd: j, seqId: selSeqId}))
+        positions.push(new possel({xStart: j, xEnd: j, seqId: idxToSeqIdMap[selSeqIdIdx]}))
       }
       this._addSelection(positions)
     } else {

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -39,6 +39,7 @@ const SelectionManager = Collection.extend({
       });
 
       return this.listenTo(this.g, "background:click", function(_e) {
+        _updateLastSelection(null);
         return this.reset();
       });
     }

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -441,7 +441,7 @@ const SelectionManager = Collection.extend({
       }
       this.add(positions, {silent: true});
     } else if (lastSelectionType === "label" && selectionType === "label" ) {
-      // Select all residues between the last selection and the current selection
+      // Select all labels between the last selection and the current selection
       const labels = [];
       for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
         labels.push(new labelsel({seqId: idxToSeqIdMap[i]}));

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -346,6 +346,7 @@ const SelectionManager = Collection.extend({
       models.push(new labelsel({ seqId: sequences[seqId].id }));
     });
     this.reset(models, {silent});
+    _updateLastSelection(null);
   },
 
   _refineSelections: function() {
@@ -588,8 +589,8 @@ const SelectionManager = Collection.extend({
       this.reset(this._getSelsWithLabelsForRows([selection]), {silent: true});
     }
 
-    this._updateLastSelection(selection);
     this._refineSelections();
+    this._updateLastSelection(selection);
   },
 
   // experimental reduce method for columns

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -48,8 +48,8 @@ const SelectionManager = Collection.extend({
     return this.find(function(el) { return el.get("type") === "label" && el.get("seqId") === seqId; });
   },
 
-  isResidueSelected: function(seqId) {
-    return this.find(function(el) { return (el.get("type") === "pos" || el.get("type") === "row") && el.get("seqId") === seqId; });
+  isSomeResidueSelected: function(seqId) {
+    return this.find(function(el) { return ((el.get("type") === "pos" || el.get("type") === "row") && el.get("seqId") === seqId) || el.get("type") === "column"; });
   },
 
   getSelForRow: function(seqId) {

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -297,7 +297,7 @@ const SelectionManager = Collection.extend({
     return selectionData;
   },
 
-  resetColFromSelData: function(selectionData, silent = false) {
+  setSelectionData: function(selectionData, silent = false) {
     const sequences = this._getSequences();
     const models = [];
     const completelySelectedRows = [];
@@ -360,7 +360,7 @@ const SelectionManager = Collection.extend({
     // Refine the selection to remove any overlapping selections (convert pos selections to row or column selections if possible) 
     // and reduce contiguous columns or positions to groups of individual column or position selections
     const selectionData = this.getSelectionData();
-    this.resetColFromSelData(selectionData);
+    this.setSelectionData(selectionData);
   },
 
   _updateSelections: function(selectionArr, updateType, silent = false) {

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -31,11 +31,15 @@ const SelectionManager = Collection.extend({
         }));
       });
 
-      return this.listenTo(this.g, "column:click", function(e) {
+      this.listenTo(this.g, "column:click", function(e) {
         return this._handleE(e.evt, new columnsel({
           xStart: e.rowPos,
           xEnd: e.rowPos + e.stepSize - 1
         }));
+      });
+
+      return this.listenTo(this.g, "background:click", function(_e) {
+        return this.reset();
       });
     }
   },

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -39,7 +39,7 @@ const SelectionManager = Collection.extend({
       });
 
       return this.listenTo(this.g, "background:click", function(_e) {
-        _updateLastSelection(null);
+        this._updateLastSelection(null);
         return this.reset();
       });
     }
@@ -346,7 +346,6 @@ const SelectionManager = Collection.extend({
       models.push(new labelsel({ seqId: sequences[seqId].id }));
     });
     this.reset(models, {silent});
-    _updateLastSelection(null);
   },
 
   _refineSelections: function() {

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -314,7 +314,7 @@ const SelectionManager = Collection.extend({
     const models = [];
     const completelySelectedRows = [];
     _.forEach(sequences, (sequence) => {
-      if (filteredSelectionData[sequence.id].selectedResidues.length === sequence.seq?.length) {
+      if (sequence.seq && filteredSelectionData[sequence.id].selectedResidues.length === sequence.seq.length) {
         completelySelectedRows.push(sequence.id);
       }
     });

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -69,6 +69,7 @@ const SelectionManager = Collection.extend({
      case "column":  return new columnsel(model);
      case "row":  return new rowsel(model);
      case "pos":  return new possel(model);
+     case "label":  return new labelsel(model);
    }
   },
 
@@ -219,8 +220,8 @@ const SelectionManager = Collection.extend({
   },
 
   _handleE: function(e, selection) {
-    const lastSelection = selection;
     if (e.ctrlKey || e.metaKey) {
+      this._updateLastSelection(selection);
       if (this._isAlreadySelected(selection, this.models)) {
         this.remove(this._modelsToRemove(selection, this.models))
       } else {
@@ -230,9 +231,9 @@ const SelectionManager = Collection.extend({
       this._handleShiftSelection(selection);
     }
     else {
+      this._updateLastSelection(selection);
       this._resetSelection(selection);
     }
-    this._updateLastSelection(lastSelection);
   },
 
   _addSelection: function(selection) {
@@ -260,6 +261,7 @@ const SelectionManager = Collection.extend({
 
   _handleShiftSelection: function(selection) {
     const lastSelection = this.lastSelection;
+    this._updateLastSelection(selection);
 
     if (!lastSelection) {
       this._addSelection(selection);

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -398,7 +398,7 @@ const SelectionManager = Collection.extend({
     const lastSelection = this.lastSelection;
 
     if (!lastSelection || !this._isSelectionValid(lastSelection)) {
-      this.add(_getSelsWithLabelsForRows([selection]), {silent: true});
+      this.add(this._getSelsWithLabelsForRows([selection]), {silent: true});
       return;
     }
 
@@ -423,7 +423,7 @@ const SelectionManager = Collection.extend({
       for (let i = minSeqIdIdx; i <= maxSeqIdIdx; i++) {
         selections.push(new rowsel({seqId: idxToSeqIdMap[i]}));
       }
-      this.add(_getSelsWithLabelsForRows(selections), {silent: true});
+      this.add(this._getSelsWithLabelsForRows(selections), {silent: true});
     } else if (lastSelectionType === "column" && selectionType === "column") {
       // Select all columns between the last selection and the current selection
       const columns = [];
@@ -463,7 +463,7 @@ const SelectionManager = Collection.extend({
       this.add(positions, {silent: true});
     } else {
       // Select the current selection
-      this.add(_getSelsWithLabelsForRows([selection]), {silent: true});
+      this.add(this._getSelsWithLabelsForRows([selection]), {silent: true});
     }
   },
 
@@ -563,13 +563,13 @@ const SelectionManager = Collection.extend({
       if (this._isAlreadySelected(selection)) {
         this._deselectSelection(selection);
       } else {
-        this.add(_getSelsWithLabelsForRows([selection]), {silent: true});
+        this.add(this._getSelsWithLabelsForRows([selection]), {silent: true});
       }
     } else if (e.shiftKey) {
       this._handleShiftSelection(selection);
     }
     else {
-      this.reset(_getSelsWithLabelsForRows([selection]), {silent: true});
+      this.reset(this._getSelsWithLabelsForRows([selection]), {silent: true});
     }
 
     this._updateLastSelection(selection);

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -114,7 +114,7 @@ extend(CanvasSelection.prototype, {
     const beforeWidth = this.ctx.lineWidth;
     this.ctx.lineWidth = 3;
     const beforeStyle = this.ctx.strokeStyle;
-    this.ctx.strokeStyle = "#FF0000";
+    this.ctx.strokeStyle = "#1A53A0";
 
     xZero += k * boxWidth;
 

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -114,6 +114,7 @@ extend(CanvasSelection.prototype, {
     const beforeWidth = this.ctx.lineWidth;
     this.ctx.lineWidth = 3;
     const beforeStyle = this.ctx.strokeStyle;
+    // #1A53A0 color is Fun Blue (https://chir.ag/projects/name-that-color/)
     this.ctx.strokeStyle = "#1A53A0";
 
     xZero += k * boxWidth;

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -100,7 +100,7 @@ const View = boneView.extend({
     const events = this.scrollBody.getScrollEvents();
 
     if (this.g.config.get("registerMouseClicks")) {
-      events.dblclick = "_onclick";
+      events.click = "_onclick";
     }
     if (this.g.config.get("registerMouseHover")) {
       events.mousein = "_onmousein";

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -235,6 +235,8 @@ const View = boneView.extend({
       } else {
         this.g.trigger("residue:click", res);
       }
+    } else {
+      this.g.trigger("background:click", e);
     }
     return this.throttledDraw();
   },

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -236,6 +236,7 @@ const View = boneView.extend({
         this.g.trigger("residue:click", res);
       }
     } else {
+      // Triggered when clicking on the unpainted section of the canvas
       this.g.trigger("background:click", e);
     }
     return this.throttledDraw();

--- a/src/views/labels/LabelBlock.js
+++ b/src/views/labels/LabelBlock.js
@@ -43,6 +43,7 @@ const View = boneView.extend({
     const labelRows = this.$el.find(".biojs_msa_labelrow").toArray();
     const isClickOnLabelRow = some(labelRows, labelrow => labelrow.contains(e.target));
     if (!isClickOnLabelRow) {
+      // Triggered when clicking on the remaining space of the label block (not on a label row)
       this.g.trigger("background:click", e);
     }
   },

--- a/src/views/labels/LabelBlock.js
+++ b/src/views/labels/LabelBlock.js
@@ -1,6 +1,6 @@
 const boneView = require("backbone-childs");
 import LabelRowView from "./LabelRowView";
-import { defer } from "lodash";
+import { some, defer } from "lodash";
 
 const View = boneView.extend({
 
@@ -34,7 +34,18 @@ const View = boneView.extend({
   },
 
   events:
-    {"scroll": "_sendScrollEvent"},
+    { 
+      "click": "_onClick",
+      "scroll": "_sendScrollEvent"
+    },
+
+  _onClick: function(e) {
+    const labelRows = this.$el.find(".biojs_msa_labelrow").toArray();
+    const isClickOnLabelRow = some(labelRows, labelrow => labelrow.contains(e.target));
+    if (!isClickOnLabelRow) {
+      this.g.trigger("background:click", e);
+    }
+  },
 
   // broadcast the scrolling event (by the scrollbar)
   _sendScrollEvent: function() {

--- a/src/views/labels/LabelRowView.js
+++ b/src/views/labels/LabelRowView.js
@@ -45,7 +45,7 @@ const View = boneView.extend({
 
   setSelection: function() {
     var isLabelSelected = this.g.selcol.isLabelSelected(this.model.id);
-    var isResidueSelected = this.g.selcol.isResidueSelected(this.model.id);
+    var isResidueSelected = this.g.selcol.isSomeResidueSelected(this.model.id);
     if (isLabelSelected) {
       return this.el.style.backgroundColor = "#B5C3DD";
     } else if (isResidueSelected) {

--- a/src/views/labels/LabelRowView.js
+++ b/src/views/labels/LabelRowView.js
@@ -44,11 +44,14 @@ const View = boneView.extend({
   },
 
   setSelection: function() {
-    var sel = this.g.selcol.getSelForRow(this.model.id);
-    if (sel.length > 0) {
-      return this.el.style.fontWeight = "bold";
+    var isLabelSelected = this.g.selcol.isLabelSelected(this.model.id);
+    var isResidueSelected = this.g.selcol.isResidueSelected(this.model.id);
+    if (isLabelSelected) {
+      return this.el.style.backgroundColor = "#B5C3DD";
+    } else if (isResidueSelected) {
+      return this.el.style.backgroundColor = "#E7ECF4";
     } else {
-      return this.el.style.fontWeight = "normal";
+      return this.el.style.backgroundColor = "white";
     }
   }
 });

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -125,7 +125,6 @@ const LabelView = view.extend({
   }, 200),
 
   _ondblclick: function(evt) {
-    console.log("dblclick", evt);
     this.dlbclicked = true;
     var seqId = this.model.get("id");
     return this.g.trigger("row:click", {seqId:seqId, evt:evt});

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -14,6 +14,7 @@ const LabelView = view.extend({
     var events = {};
     if (this.g.config.get("registerMouseClicks")) {
       events.click = "_onclick";
+      events.dblclick = "_ondblclick";
     }
     if (this.g.config.get("registerMouseHover")) {
       events.mousein = "_onmousein";
@@ -115,7 +116,17 @@ const LabelView = view.extend({
     return id;
   },
 
-  _onclick: function(evt) {
+  _onclick: _.debounce(function(evt) {
+    if (this.dlbclicked) {
+      return this.dlbclicked = false;
+    }
+    var seqId = this.model.get("id");
+    return this.g.trigger("label:click", {seqId:seqId, evt:evt});
+  }, 200),
+
+  _ondblclick: function(evt) {
+    console.log("dblclick", evt);
+    this.dlbclicked = true;
     var seqId = this.model.get("id");
     return this.g.trigger("row:click", {seqId:seqId, evt:evt});
   },


### PR DESCRIPTION
Jira: [LDTOOLS-142
](https://schrodinger.atlassian.net/browse/LDTOOLS-142)
User Story: [Selecting Entity and monomers in the sequence viewer ](https://schrodinger.atlassian.net/wiki/spaces/LD/pages/547651596/Selecting+Entity+and+monomers+in+the+sequence+viewer)
Primary: @karry08 @pradeepnschrodinger 

Overview of the changes: 
Before we talk about the changes, I'd like to discuss how selections are maintained by MSA viewer. MSA viewer had three models corresponding to row, column, and position selections (`rowsel, columnsel, and possel`). As a new requirement, we wanted the capability to select labels independently of residues (earlier, the selection of labels was inferred from the selection of residues - a label was considered selected if one or more residues for the label were selected). We introduced a new selection model - `labelsel` to achieve this behavior. The `SelectionCol.js` contains a `Backbone.js` collection which stores the selection information using the models above - `rowsel, columnsel, possel, and labelsel`.  
Next, we introduced two APIs: `getSelectionData()` and `setSelectionData()` in the MSA viewer. `getSelectionData()` returns the selection data (maintained in terms of models) as an object. Using `setSelectionData()`, we can reset the selection of MSA by supplying selection data as an object. The format of the selection data is as follows:

```
selectionData = {
  selectedRows: (string | number)[]
  selectedColumns: number[]
  selectedPositions: {seqId: string | number; columnIndex: number}[]
  selectedLabels: (string | number)[]
}
```
We have implemented Ctrl/Cmd selection, Ctrl/Cmd de-selection, Shift selection, and complete de-selection when clicking on the viewer's white space—the behavior of how these work is described in comments for the respective functions. One important thing to note is - we're refining the selections after each selection. Refining primarily comprises (i) Removing any overlapping or duplicate models/selections and (ii) Breaking down contiguous column or position selections into multiple individual column or position selections, respectively. This helps us when we have to perform operations like de-selection, etc.

Demo:
https://github.com/user-attachments/assets/869bc880-b00f-43ef-a5cf-e266542de151
