### PR TITLE
LDTOOLS-193: Sequence_Viewer: Selection box should be complete at the edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,8 +438,8 @@ zoomer: {
     // general
     alignmentWidth: "auto",
     alignmentHeight: 225,
-    columnWidth: 15,
-    rowHeight: 15,
+    columnWidth: 17,
+    rowHeight: 17,
     autoResize: true, // only for the width
     selectionBorderWidth: 2, // sets the thickness of selection borders for residue selection
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ zoomer: {
     columnWidth: 15,
     rowHeight: 15,
     autoResize: true, // only for the width
+    selectionBorderWidth: 2, // sets the thickness of selection borders for residue selection
 
     // labels
     textVisible: true,

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -53,12 +53,18 @@ const SelectionManager = Collection.extend({
     return this.find(function(el) { return el.get("type") === "label" && el.get("seqId") === seqId; });
   },
 
-  isSomeResidueSelected: function(seqId) {
+  isAnyResidueSelectedInRow: function(seqId) {
     // Check if there is a row selection or a position selection for the given seqId, or if there is a column selection - in which case at least one residue is selected for all rows
     return this.find(function(el) {
       const isRowOrPositionModelForSeqId = (el.get("type") === "pos" || el.get("type") === "row") && el.get("seqId") === seqId;
       const isColumnModel = el.get("type") === "column";
       return isRowOrPositionModelForSeqId || isColumnModel;
+    });
+  },
+
+  isAnyResidueSelected: function() {
+    return this.find(function(el) {
+      return el.get("type") !== "label";
     });
   },
 

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -171,9 +171,7 @@ module.exports = Zoomer = Model.extend({
     }
 
     //@set "alignmentWidth", val
-    // Note(ritik): Added extra pixels to fix the border getting clipped for last residue selection in sequences
-    const widthAdjustment = this.get("selectionBorderWidth") / 2;
-    this.set("alignmentWidth", val + widthAdjustment)
+    this.set("alignmentWidth", val)
     return val;
   },
 

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -32,8 +32,8 @@ module.exports = Zoomer = Model.extend({
     // general
     alignmentWidth: "auto",
     alignmentHeight: 225,
-    columnWidth: 15,
-    rowHeight: 15,
+    columnWidth: 18,
+    rowHeight: 18,
     autoResize: true, // only for the width
 
     // labels

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -170,7 +170,8 @@ module.exports = Zoomer = Model.extend({
     }
 
     //@set "alignmentWidth", val
-    this.set("alignmentWidth", val)
+    // Note(ritik): Added 1px to fix the border getting clipped for last residue selection in sequences
+    this.set("alignmentWidth", val + 1)
     return val;
   },
 

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -35,6 +35,7 @@ module.exports = Zoomer = Model.extend({
     columnWidth: 17,
     rowHeight: 17,
     autoResize: true, // only for the width
+    selectionBorderWidth: 2,
 
     // labels
     labelIdLength: 20,
@@ -170,8 +171,9 @@ module.exports = Zoomer = Model.extend({
     }
 
     //@set "alignmentWidth", val
-    // Note(ritik): Added 1px to fix the border getting clipped for last residue selection in sequences
-    this.set("alignmentWidth", val + 1)
+    // Note(ritik): Added extra pixels to fix the border getting clipped for last residue selection in sequences
+    const widthAdjustment = this.get("selectionBorderWidth") / 2;
+    this.set("alignmentWidth", val + widthAdjustment)
     return val;
   },
 

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -151,7 +151,7 @@ module.exports = Zoomer = Model.extend({
   _adjustWidth: function() {
     if (!(this.el !== undefined && this.model !== undefined)) { return; }
 
-    var calcWidth = this.getAlignmentWidth( this.model.getMaxLength() - this.g.columns.get('hidden').length) + 10;
+    var calcWidth = this.getAlignmentWidth( this.model.getMaxLength() - this.g.columns.get('hidden').length);
 
     let val
     if (this.g.config.get("shouldRenderSeqBlockAsSvg") === true) {

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -32,8 +32,8 @@ module.exports = Zoomer = Model.extend({
     // general
     alignmentWidth: "auto",
     alignmentHeight: 225,
-    columnWidth: 18,
-    rowHeight: 18,
+    columnWidth: 17,
+    rowHeight: 17,
     autoResize: true, // only for the width
 
     // labels

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -151,7 +151,7 @@ module.exports = Zoomer = Model.extend({
   _adjustWidth: function() {
     if (!(this.el !== undefined && this.model !== undefined)) { return; }
 
-    var calcWidth = this.getAlignmentWidth( this.model.getMaxLength() - this.g.columns.get('hidden').length);
+    var calcWidth = this.getAlignmentWidth( this.model.getMaxLength() - this.g.columns.get('hidden').length) + 10;
 
     let val
     if (this.g.config.get("shouldRenderSeqBlockAsSvg") === true) {

--- a/src/model/SeqCollection.js
+++ b/src/model/SeqCollection.js
@@ -43,7 +43,10 @@ const SeqCollection = Collection.extend({
   // true: returns the last element, false: returns undefined
   prev: function(model, endless) {
     let index = this.indexOf(model) - 1;
-    if (index < 0 && endless) { index = this.length - 1; }
+    if (index < 0) { 
+      if (endless) { index = this.length - 1; }
+      else { return null; }
+    }
     return this.at(index);
   },
 
@@ -52,7 +55,10 @@ const SeqCollection = Collection.extend({
   // true: returns the first element, false: returns undefined
   next: function(model, endless) {
     let index = this.indexOf(model) + 1;
-    if (index === this.length && endless) { index = 0; }
+    if (index === this.length ) { 
+      if (endless) { index = 0; }
+      else { return null; }
+    }
     return this.at(index);
   },
 

--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -159,7 +159,8 @@ class ScrollBody {
 
     // These calculations are taken from src/views/canvas/CanvasCoordsCache.js:
     const maxScrollHeight = this.g.zoomer.getMaxAlignmentHeight() - this.g.zoomer.get('alignmentHeight');
-    const maxScrollWidth = this.g.zoomer.getMaxAlignmentWidth() - this.g.zoomer.getAlignmentWidth();
+    // // Note(ritik): Added 1px to fix the border getting clipped for last residue selection in scrollable sequences
+    const maxScrollWidth = this.g.zoomer.getMaxAlignmentWidth() - this.g.zoomer.getAlignmentWidth() + 1;
 
     // 0: maxLeft, 1: maxTop
     const max = [maxScrollWidth, maxScrollHeight];

--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -159,8 +159,9 @@ class ScrollBody {
 
     // These calculations are taken from src/views/canvas/CanvasCoordsCache.js:
     const maxScrollHeight = this.g.zoomer.getMaxAlignmentHeight() - this.g.zoomer.get('alignmentHeight');
-    // // Note(ritik): Added 1px to fix the border getting clipped for last residue selection in scrollable sequences
-    const maxScrollWidth = this.g.zoomer.getMaxAlignmentWidth() - this.g.zoomer.getAlignmentWidth() + 1;
+    // // Note(ritik): Added extra pixels to fix the border getting clipped for last residue selection in scrollable sequences
+    const scrollWidthAdjustment = this.g.zoomer.get("selectionBorderWidth") / 2;
+    const maxScrollWidth = this.g.zoomer.getMaxAlignmentWidth() - this.g.zoomer.getAlignmentWidth() + scrollWidthAdjustment;
 
     // 0: maxLeft, 1: maxTop
     const max = [maxScrollWidth, maxScrollHeight];

--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -159,9 +159,7 @@ class ScrollBody {
 
     // These calculations are taken from src/views/canvas/CanvasCoordsCache.js:
     const maxScrollHeight = this.g.zoomer.getMaxAlignmentHeight() - this.g.zoomer.get('alignmentHeight');
-    // // Note(ritik): Added extra pixels to fix the border getting clipped for last residue selection in scrollable sequences
-    const scrollWidthAdjustment = this.g.zoomer.get("selectionBorderWidth") / 2;
-    const maxScrollWidth = this.g.zoomer.getMaxAlignmentWidth() - this.g.zoomer.getAlignmentWidth() + scrollWidthAdjustment;
+    const maxScrollWidth = this.g.zoomer.getMaxAlignmentWidth() - this.g.zoomer.getAlignmentWidth();
 
     // 0: maxLeft, 1: maxTop
     const max = [maxScrollWidth, maxScrollHeight];

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -46,9 +46,6 @@ extend(CanvasSelection.prototype, {
     const mPrevSel = getNextPrev[0];
     const mNextSel = getNextPrev[1];
 
-    const boxWidth = this.g.zoomer.get("columnWidth");
-    const boxHeight = this.g.zoomer.get("rowHeight");
-
     // avoid unnecessary loops
     if (selection.length === 0) { return; }
 
@@ -134,10 +131,10 @@ extend(CanvasSelection.prototype, {
     // split up the selection into single cells
     let xPart = 0;
 
-    let firstSelectedResidueBottomBorder = false;
-    let firstSelectedResidueTopBorder = false;
-    let lastSelectedResidueBottomBorder = false;
-    let lastSelectedResidueTopBorder = false;
+    let firstSelectedResidueHasBottomBorder = false;
+    let firstSelectedResidueHasTopBorder = false;
+    let lastSelectedResidueHasBottomBorder = false;
+    let lastSelectedResidueHasTopBorder = false;
 
     const end1 = selectionLength - 1;
     for (let i = 0; i <= end1; i++) {
@@ -150,10 +147,10 @@ extend(CanvasSelection.prototype, {
         this.ctx.moveTo(xZero + xPart, yZero + adjustment);
         this.ctx.lineTo(xPart + boxWidth + xZero, yZero + adjustment);
         if (i === 0) {
-          firstSelectedResidueTopBorder = true;
+          firstSelectedResidueHasTopBorder = true;
         } 
         if (i === end1) {
-          lastSelectedResidueTopBorder = true;
+          lastSelectedResidueHasTopBorder = true;
         }
       }
       // lower line
@@ -161,10 +158,10 @@ extend(CanvasSelection.prototype, {
         this.ctx.moveTo(xPart + xZero, boxHeight + yZero - adjustment);
         this.ctx.lineTo(xPart + boxWidth + xZero, boxHeight + yZero - adjustment);
         if (i === 0) {
-          firstSelectedResidueBottomBorder = true;
+          firstSelectedResidueHasBottomBorder = true;
         } 
         if (i === end1) {
-          lastSelectedResidueBottomBorder = true;
+          lastSelectedResidueHasBottomBorder = true;
         }
       }
 
@@ -177,9 +174,9 @@ extend(CanvasSelection.prototype, {
 
     // draw vertical borders
     // left border
-    this._drawVerticalBorder(leftX, yStart, yEnd, firstSelectedResidueTopBorder, firstSelectedResidueBottomBorder);
+    this._drawVerticalBorder(leftX, yStart, yEnd, firstSelectedResidueHasTopBorder, firstSelectedResidueHasBottomBorder);
     // right border
-    this._drawVerticalBorder(rightX, yStart, yEnd, lastSelectedResidueTopBorder, lastSelectedResidueBottomBorder);
+    this._drawVerticalBorder(rightX, yStart, yEnd, lastSelectedResidueHasTopBorder, lastSelectedResidueHasBottomBorder);
 
     this.ctx.stroke();
     this.ctx.strokeStyle = beforeStyle;

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -167,7 +167,7 @@ extend(CanvasSelection.prototype, {
       xPart += boxWidth;
     }
     const leftX = xZero + adjustment;
-    const rightX = xZero + totalWidth - adjustment;
+    const rightX = xZero + totalWidth - 2 * adjustment;
     const yStart = yZero;
     const yEnd = yZero + boxHeight;
 

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -123,7 +123,7 @@ extend(CanvasSelection.prototype, {
 
     this.ctx.beginPath();
     const beforeWidth = this.ctx.lineWidth;
-    this.ctx.lineWidth = 2;
+    this.ctx.lineWidth = this.g.zoomer.get("selectionBorderWidth");
     const beforeStyle = this.ctx.strokeStyle;
     // #1A53A0 color is Fun Blue (https://chir.ag/projects/name-that-color/)
     this.ctx.strokeStyle = "#1A53A0";

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -116,6 +116,7 @@ extend(CanvasSelection.prototype, {
     const beforeStyle = this.ctx.strokeStyle;
     // #1A53A0 color is Fun Blue (https://chir.ag/projects/name-that-color/)
     this.ctx.strokeStyle = "#1A53A0";
+    const adjustment = this.ctx.lineWidth / 2;
 
     xZero += k * boxWidth;
 
@@ -129,25 +130,25 @@ extend(CanvasSelection.prototype, {
       }
       // upper line
       if (!((typeof mPrevSel !== "undefined" && mPrevSel !== null) && mPrevSel.indexOf(xPos) >= 0)) {
-        this.ctx.moveTo(xZero + xPart, yZero);
-        this.ctx.lineTo(xPart + boxWidth + xZero, yZero);
+        this.ctx.moveTo(xZero + xPart, yZero + adjustment);
+        this.ctx.lineTo(xPart + boxWidth + xZero, yZero + adjustment);
       }
       // lower line
       if (!((typeof mNextSel !== "undefined" && mNextSel !== null) && mNextSel.indexOf(xPos) >= 0)) {
-        this.ctx.moveTo(xPart + xZero, boxHeight + yZero);
-        this.ctx.lineTo(xPart + boxWidth + xZero, boxHeight + yZero);
+        this.ctx.moveTo(xPart + xZero, boxHeight + yZero - adjustment);
+        this.ctx.lineTo(xPart + boxWidth + xZero, boxHeight + yZero - adjustment);
       }
 
       xPart += boxWidth;
     }
 
     // left
-    this.ctx.moveTo(xZero,yZero);
-    this.ctx.lineTo(xZero, boxHeight + yZero);
+    this.ctx.moveTo(xZero + adjustment,yZero);
+    this.ctx.lineTo(xZero + adjustment, boxHeight + yZero);
 
     // right
-    this.ctx.moveTo(xZero + totalWidth,yZero);
-    this.ctx.lineTo(xZero + totalWidth, boxHeight + yZero);
+    this.ctx.moveTo(xZero + totalWidth - adjustment,yZero);
+    this.ctx.lineTo(xZero + totalWidth - adjustment, boxHeight + yZero);
 
     this.ctx.stroke();
     this.ctx.strokeStyle = beforeStyle;

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -77,15 +77,16 @@ extend(CanvasSelection.prototype, {
     })();
   },
 
-  _drawVerticalLine: function (xStart, yStart, yEnd) {
-    this.ctx.moveTo(xStart, yStart);
-    this.ctx.lineTo(xStart, yEnd);
+  _drawHorizontalBorder: function (yPos, xStart, xEnd) {
+    this.ctx.moveTo(xStart, yPos);
+    this.ctx.lineTo(xEnd, yPos);
   },
 
   _drawVerticalBorder: function (xPos, yStart, yEnd, hasTopBorder, hasBottomBorder) {
     const adjustedYStart = hasTopBorder ? yStart : yStart - this.ctx.lineWidth;
     const adjustedYEnd = hasBottomBorder ? yEnd : yEnd + this.ctx.lineWidth;
-    this._drawVerticalLine(xPos, adjustedYStart, adjustedYEnd);
+    this.ctx.moveTo(xPos, adjustedYStart);
+    this.ctx.lineTo(xPos, adjustedYEnd);
   },
 
   // draws a single user selection
@@ -144,8 +145,7 @@ extend(CanvasSelection.prototype, {
       }
       // upper line
       if (!((typeof mPrevSel !== "undefined" && mPrevSel !== null) && mPrevSel.indexOf(xPos) >= 0)) {
-        this.ctx.moveTo(xZero + xPart, yZero + adjustment);
-        this.ctx.lineTo(xPart + boxWidth + xZero, yZero + adjustment);
+        this._drawHorizontalBorder(yZero + adjustment, xZero + xPart, xZero + xPart + boxWidth);
         if (i === 0) {
           firstSelectedResidueHasTopBorder = true;
         } 
@@ -155,8 +155,7 @@ extend(CanvasSelection.prototype, {
       }
       // lower line
       if (!((typeof mNextSel !== "undefined" && mNextSel !== null) && mNextSel.indexOf(xPos) >= 0)) {
-        this.ctx.moveTo(xPart + xZero, boxHeight + yZero - adjustment);
-        this.ctx.lineTo(xPart + boxWidth + xZero, boxHeight + yZero - adjustment);
+        this._drawHorizontalBorder(yZero + boxHeight - adjustment, xZero + xPart, xZero + xPart + boxWidth);
         if (i === 0) {
           firstSelectedResidueHasBottomBorder = true;
         } 

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -174,7 +174,7 @@ const Drawer = {
       that.ctx.textBaseline = "middle";
       that.ctx.fillText(data.c, data.xPos + data.rectWidth / 2, data.yPos + data.rectHeight - data.rectHeight / 2);
     } else {
-      return that.ctx.drawImage( that.cache.getFontTile(data.c, data.rectWidth, data.rectHeight, data.x, data.y, data.isSelected), data.xPos, data.yPos, data.rectWidth, data.rectHeight);
+      return that.ctx.drawImage( that.cache.getFontTile(data.c, data.rectWidth, data.rectHeight, data.x, data.y), data.xPos, data.yPos, data.rectWidth, data.rectHeight);
     }
   },
 };

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -154,7 +154,7 @@ const Drawer = {
       y: data.y
     });
     if ((typeof color !== "undefined" && color !== null)) {
-      that.ctx.globalAlpha = data.isSelected? 1: (data.isNothingSelected)? 1: 0.7;
+      that.ctx.globalAlpha = data.isSelected? 1: (data.isNothingSelected)? 1: 0.65;
       that.ctx.fillStyle = color;
       that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);
       return that.ctx.globalAlpha = 1;

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -154,6 +154,8 @@ const Drawer = {
       y: data.y
     });
     if ((typeof color !== "undefined" && color !== null)) {
+      // NOTE (ritik): Change the opacity of non-selected residues to 65% whenever there is a residue selection
+      // This is done to make the selected residues more prominent
       that.ctx.globalAlpha = data.isSelected? 1: (data.hasResidueSelection)? 0.65: 1;
       that.ctx.fillStyle = color;
       that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -107,7 +107,7 @@ const Drawer = {
     const seq = data.model.get("seq");
     const seqId = data.model.get("id");
     const seqSelection = this.g.selcol.getBlocksForRow(seqId, seq.length);
-    const isNothingSelected = this.g.selcol.isEmpty();
+    const hasResidueSelections = this.g.selcol.isAnyResidueSelected();
     const y = data.yPos;
     const rectWidth = this.rectWidth;
     const rectHeight = this.rectHeight;
@@ -128,7 +128,7 @@ const Drawer = {
       res.c = c;
       res.xPos = x;
       res.isSelected = seqSelection.includes(j);
-      res.isNothingSelected = isNothingSelected;
+      res.hasResidueSelections = hasResidueSelections;
 
       // local call is faster than apply
       // http://jsperf.com/function-calls-direct-vs-apply-vs-call-vs-bind/6
@@ -154,7 +154,7 @@ const Drawer = {
       y: data.y
     });
     if ((typeof color !== "undefined" && color !== null)) {
-      that.ctx.globalAlpha = data.isSelected? 1: (data.isNothingSelected)? 1: 0.65;
+      that.ctx.globalAlpha = data.isSelected? 1: (data.hasResidueSelections)? 0.65: 1;
       that.ctx.fillStyle = color;
       that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);
       return that.ctx.globalAlpha = 1;

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -105,6 +105,9 @@ const Drawer = {
   // TODO: very expensive method
   drawSeq: function(data, callback) {
     const seq = data.model.get("seq");
+    const seqId = data.model.get("id");
+    const seqSelection = this.g.selcol.getBlocksForRow(seqId, seq.length);
+    const isNothingSelected = this.g.selcol.isEmpty();
     const y = data.yPos;
     const rectWidth = this.rectWidth;
     const rectHeight = this.rectHeight;
@@ -124,6 +127,8 @@ const Drawer = {
       res.x = j;
       res.c = c;
       res.xPos = x;
+      res.isSelected = seqSelection.includes(j);
+      res.isNothingSelected = isNothingSelected;
 
       // local call is faster than apply
       // http://jsperf.com/function-calls-direct-vs-apply-vs-call-vs-bind/6
@@ -149,8 +154,10 @@ const Drawer = {
       y: data.y
     });
     if ((typeof color !== "undefined" && color !== null)) {
+      that.ctx.globalAlpha = data.isSelected? 1: (data.isNothingSelected)? 1: 0.7;
       that.ctx.fillStyle = color;
-      return that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);
+      that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);
+      return that.ctx.globalAlpha = 1;
     }
   },
 
@@ -165,7 +172,7 @@ const Drawer = {
       that.ctx.textBaseline = "middle";
       that.ctx.fillText(data.c, data.xPos + data.rectWidth / 2, data.yPos + data.rectHeight - data.rectHeight / 2);
     } else {
-      return that.ctx.drawImage( that.cache.getFontTile(data.c, data.rectWidth, data.rectHeight, data.x, data.y), data.xPos, data.yPos, data.rectWidth, data.rectHeight);
+      return that.ctx.drawImage( that.cache.getFontTile(data.c, data.rectWidth, data.rectHeight, data.x, data.y, data.isSelected), data.xPos, data.yPos, data.rectWidth, data.rectHeight);
     }
   },
 };

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -107,7 +107,7 @@ const Drawer = {
     const seq = data.model.get("seq");
     const seqId = data.model.get("id");
     const seqSelection = this.g.selcol.getBlocksForRow(seqId, seq.length);
-    const hasResidueSelections = this.g.selcol.isAnyResidueSelected();
+    const hasResidueSelection = this.g.selcol.isAnyResidueSelected();
     const y = data.yPos;
     const rectWidth = this.rectWidth;
     const rectHeight = this.rectHeight;
@@ -128,7 +128,7 @@ const Drawer = {
       res.c = c;
       res.xPos = x;
       res.isSelected = seqSelection.includes(j);
-      res.hasResidueSelections = hasResidueSelections;
+      res.hasResidueSelection = hasResidueSelection;
 
       // local call is faster than apply
       // http://jsperf.com/function-calls-direct-vs-apply-vs-call-vs-bind/6
@@ -154,7 +154,7 @@ const Drawer = {
       y: data.y
     });
     if ((typeof color !== "undefined" && color !== null)) {
-      that.ctx.globalAlpha = data.isSelected? 1: (data.hasResidueSelections)? 0.65: 1;
+      that.ctx.globalAlpha = data.isSelected? 1: (data.hasResidueSelection)? 0.65: 1;
       that.ctx.fillStyle = color;
       that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);
       return that.ctx.globalAlpha = 1;

--- a/src/views/labels/LabelRowView.js
+++ b/src/views/labels/LabelRowView.js
@@ -45,7 +45,7 @@ const View = boneView.extend({
 
   setSelection: function() {
     var isLabelSelected = this.g.selcol.isLabelSelected(this.model.id);
-    var isResidueSelected = this.g.selcol.isSomeResidueSelected(this.model.id);
+    var isResidueSelected = this.g.selcol.isAnyResidueSelectedInRow(this.model.id);
     if (isLabelSelected) {
       return this.el.style.backgroundColor = "#B5C3DD";
     } else if (isResidueSelected) {


### PR DESCRIPTION
Primary: @pradeepnschrodinger 

Summary:
There were multiple issues in the ticket:
(a) Actual disappearance of borders when we selected the same residues in the first and last row (this can be noticed when you select an entire column; the border in the first row appears to be missing. This essentially happened when you select the same residues in the first and last rows.)
![image](https://github.com/user-attachments/assets/9a038e3e-211f-428c-918b-d914f3fbc3f8)

(b) The second concern was that borders were getting clipped (some pixels) for elements present at the end. In order to resolve this, I had to internalize the border (border is now within the boundaries of a monomer tile) and increase the dimensions of the monomer tile accordingly 
![image](https://github.com/user-attachments/assets/8af0ab64-8693-43de-a7ff-9742ff703e79)

(c) Additionally, I also fixed the issue of missing pixels at border boundaries:
![image](https://github.com/user-attachments/assets/e0cc2b52-4a63-4b76-806a-1a1c4a63d884)

Updated demo:

https://github.com/user-attachments/assets/d65cd48f-4f0c-4f0b-8cd9-73e06c9bf141




