### PR TITLE
LDTOOLS-206: Sequence Viewer: Unexpected selection of residues in the white area of shorter sequences for unequal sequence lengths

### DIFF
--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -53,12 +53,12 @@ const SelectionManager = Collection.extend({
     return this.find(function(el) { return el.get("type") === "label" && el.get("seqId") === seqId; });
   },
 
-  isSomeResidueSelected: function(seqId) {
-    // Check if there is a row selection or a position selection for the given seqId, or if there is a column selection - in which case at least one residue is selected for all rows
+  isSomeResidueSelected: function(seqId, seqLen) {
+    // Check if there is a row selection or a position selection for the given seqId, or if there is a column selection within the sequence length
     return this.find(function(el) {
       const isRowOrPositionModelForSeqId = (el.get("type") === "pos" || el.get("type") === "row") && el.get("seqId") === seqId;
-      const isColumnModel = el.get("type") === "column";
-      return isRowOrPositionModelForSeqId || isColumnModel;
+      const isColumnModelWithinSequence = el.get("type") === "column" && el.get("xEnd") < seqLen;
+      return isRowOrPositionModelForSeqId || isColumnModelWithinSequence;
     });
   },
 

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -283,6 +283,7 @@ const View = boneView.extend({
     y = Math.max(0,y);
 
     const seqId = this.model.at(y).get("id");
+    const seqLen = this.model.at(y).get("seq").length;
 
     if (rowNumber > 0) {
       // click on a feature
@@ -293,6 +294,10 @@ const View = boneView.extend({
       }
     } else {
       // click on a seq
+      // check if the residue position is in the sequence
+      if (x >= seqLen) {
+        return;
+      }
       return {seqId:seqId, rowPos: x, evt:e};
     }
   },

--- a/src/views/labels/LabelRowView.js
+++ b/src/views/labels/LabelRowView.js
@@ -44,8 +44,10 @@ const View = boneView.extend({
   },
 
   setSelection: function() {
-    var isLabelSelected = this.g.selcol.isLabelSelected(this.model.id);
-    var isResidueSelected = this.g.selcol.isSomeResidueSelected(this.model.id);
+    const seqId = this.model.id;
+    const seqLen = this.model.get("seq").length;
+    var isLabelSelected = this.g.selcol.isLabelSelected(seqId);
+    var isResidueSelected = this.g.selcol.isSomeResidueSelected(seqId, seqLen);
     if (isLabelSelected) {
       return this.el.style.backgroundColor = "#B5C3DD";
     } else if (isResidueSelected) {


### PR DESCRIPTION
Primary: @pradeepnschrodinger

Summary:
MSA generated a `residue:click` event without taking into account the actual length of sequences. Consequently, we could see selections for shorter sequences even when we clicked in the white area (present horizontally). I have updated the MSA code to see the actual length of the sequence being clicked before generating a `residue:click` event. As required by the 
`Selecting Entity and monomers in the sequence viewer` user story, now the selection will also be reset when the white area (present horizontally) is clicked.

Demo:
https://drive.google.com/file/d/1DkdEfwQVZuYycWdrfMEEa8qj-JqNGQE1/view?usp=sharing