### PR TITLE
LDTOOLS-226: Seq Viewer: Changing Residue selection should not affect Entity selection and vice versa; they are independent

### DIFF
--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -552,6 +552,26 @@ const SelectionManager = Collection.extend({
     }
   },
 
+  _resetSelection: function(selection, options) {
+    // Check selection type
+    const selectionType = selection.get("type");
+    const labelSelections = _.filter(this.models, m => m.get("type") === "label");
+    const residueSelections = _.filter(this.models, m => m.get("type") !== "label");
+    if (selectionType === "label") {  // Label Selection
+      // Replace all the label selections with the new label selection
+      // Do not reset the residue selections
+      this.reset([selection, ...residueSelections], options);
+    } else if (selectionType === "column" || selectionType === "pos") {  // Residue Selection
+      // Replace all the residues selections with the new residue selection
+      // Do not reset the label selections
+      this.reset([selection, ...labelSelections], options);
+    } else { 
+      // Simultaneous Label and Residue Selection (via Row Selection)
+      // Replace all the selections with the new label & residue selection
+      this.reset(this._getSelsWithLabelsForRows([selection]), options);
+    }
+  },
+
   _handleSelectionEvent: function(e, selection) {
     if (e.ctrlKey || e.metaKey) {
       if (this._isAlreadySelected(selection)) {
@@ -563,7 +583,7 @@ const SelectionManager = Collection.extend({
       this._handleShiftSelection(selection);
     }
     else {
-      this.reset(this._getSelsWithLabelsForRows([selection]), {silent: true});
+      this._resetSelection(selection, {silent: true});
     }
 
     this._refineSelections();

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -553,7 +553,6 @@ const SelectionManager = Collection.extend({
   },
 
   _resetSelection: function(selection, options) {
-    // Check selection type
     const selectionType = selection.get("type");
     const labelSelections = _.filter(this.models, m => m.get("type") === "label");
     const residueSelections = _.filter(this.models, m => m.get("type") !== "label");
@@ -583,6 +582,7 @@ const SelectionManager = Collection.extend({
       this._handleShiftSelection(selection);
     }
     else {
+      // Click with 
       this._resetSelection(selection, {silent: true});
     }
 

--- a/src/g/selection/SelectionCol.js
+++ b/src/g/selection/SelectionCol.js
@@ -582,7 +582,6 @@ const SelectionManager = Collection.extend({
       this._handleShiftSelection(selection);
     }
     else {
-      // Click with 
       this._resetSelection(selection, {silent: true});
     }
 


### PR DESCRIPTION
Primary: @pradeepnschrodinger 

Summary:

Updated the selection behavior when a click (single or double) is made without any modifier keys (Ctrl or Shift). To make the entity & residue selections independent from each other, I'm checking for selection type (Entity or Residue) when the click is made and preserving the selections of the other kind.