### PR TITLE
LDTOOLS-219: Sequence Viewer: Column Selection borders should run across the entire column irrespective of missing residues

### DIFF
--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -52,7 +52,7 @@ extend(CanvasSelection.prototype, {
     let hiddenOffset = 0;
     return (() => {
       const result = [];
-      const end = seq.length - 1;
+      const end = this.g.seqs.getMaxLength() - 1;
       for (let n = 0; n <= end; n++) {
         result.push((() => {
           if (data.hidden.indexOf(n) >= 0) {
@@ -103,7 +103,7 @@ extend(CanvasSelection.prototype, {
 
     // get the length of this selection
     let selectionLength = 0;
-    const end = data.model.get("seq").length - 1;
+    const end = this.g.seqs.getMaxLength() - 1;
     for (let i = n; i <= end; i++) {
       if (selection.indexOf(i) >= 0) {
         selectionLength++;


### PR DESCRIPTION
Primary: @pradeepnschrodinger 

Summary: The `_getSelection()` function of `CanvasSelection.js` was already returning the selection array containing column selections that may go beyond the length of a sequence. I've updated the `_appendSelection()` and `_renderSelection()` methods to draw such selections by removing the length constraints. Consequently, we now have column selections running across entire columns.


https://github.com/user-attachments/assets/87abf8c9-37d6-467a-81c7-d2f971f498bf

