### PR TITLE
  LDTOOLS-255: Sequence Viewer: Column Ruler resets to the start when a data column is selected

### DIFF
--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -49,9 +49,9 @@ const View = boneView.extend({
 
     this.draw();
     
-    // NOTE (ritik): Selecting a custom column in Sequence Viewer was resetting the `scrollLeft` of `rheaders` to 0. To preserve the scroll on selecting a custom column,
+    // NOTE (ritik): Selecting a custom column in Sequence Viewer was resetting the `scrollLeft` of `rheaders` to 0. To preserve the scroll when selecting a custom column,
     // set the element scroll after it is mounted in the DOM. For this, we are using `defer`, which sets the `scrollLeft` of `rheaders` after the current call stack is cleared. 
-    // This ensures that the element is fully mounted and rendered in the DOM (in the previous call stack) before adjusting the scroll position.
+    // This ensures the element is fully mounted and rendered in the DOM (in the previous call stack) before adjusting the scroll position.
     _.defer(() => {
       document.querySelector('.biojs_msa_rheaders').scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");
     })

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -49,9 +49,9 @@ const View = boneView.extend({
 
     this.draw();
     
-    // NOTE (ritik): Using defer to set the scrollLeft of rheaders to delay the execution until the current call stack has cleared, ensuring that the element has
-    // been successfully mounted to the DOM. We need to set the scrollLeft in this manner because on selecting a custom column, the scrollLeft of rheaders was
-    // getting reset to 0.
+    // NOTE (ritik): Selecting a custom column in Sequence Viewer was resetting the `scrollLeft` of `rheaders` to 0. To preserve the scroll on selecting a custom column,
+    // set the element scroll after it is mounted in the DOM. For this, we are using `defer`, which sets the `scrollLeft` of `rheaders` after the current call stack is cleared. 
+    // This ensures that the element is fully mounted and rendered in the DOM (in the previous call stack) before adjusting the scroll position.
     _.defer(() => {
       document.querySelector('.biojs_msa_rheaders').scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");
     })

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -48,6 +48,13 @@ const View = boneView.extend({
     this.addView("pinnedSeqBlock", pinnedBlock);
 
     this.draw();
+    
+    // NOTE (ritik): Using defer to set the scrollLeft to delay the execution until the current call stack has cleared to ensure that the element has been
+    // successfully mounted to the DOM. We need to set the scrollLeft in this manner because on selecting a custom column, the scrollLeft of rheaders was
+    // getting reset to 0.
+    _.defer(() => {
+      document.querySelector('.biojs_msa_rheaders').scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");
+    })
 
     return this.g.vis.once('change:loaded', this._adjustScrollingLeft, this);
   },

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -50,7 +50,7 @@ const View = boneView.extend({
     this.draw();
     
     // NOTE (ritik): Selecting a custom column in Sequence Viewer was resetting the `scrollLeft` of `rheaders` to 0. To preserve the scroll when selecting a custom column,
-    // set the element scroll after it is mounted in the DOM. For this, we are using `defer`, which sets the `scrollLeft` of `rheaders` after the current call stack is cleared. 
+    // we are setting the element scroll after it is mounted in the DOM. For this, we are using `defer`, which sets the `scrollLeft` of `rheaders` after the current call stack is cleared. 
     // This ensures the element is fully mounted and rendered in the DOM (in the previous call stack) before adjusting the scroll position.
     _.defer(() => {
       document.querySelector('.biojs_msa_rheaders').scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -49,8 +49,8 @@ const View = boneView.extend({
 
     this.draw();
     
-    // NOTE (ritik): Using defer to set the scrollLeft to delay the execution until the current call stack has cleared to ensure that the element has been
-    // successfully mounted to the DOM. We need to set the scrollLeft in this manner because on selecting a custom column, the scrollLeft of rheaders was
+    // NOTE (ritik): Using defer to set the scrollLeft of rheaders to delay the execution until the current call stack has cleared, ensuring that the element has
+    // been successfully mounted to the DOM. We need to set the scrollLeft in this manner because on selecting a custom column, the scrollLeft of rheaders was
     // getting reset to 0.
     _.defer(() => {
       document.querySelector('.biojs_msa_rheaders').scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");


### PR DESCRIPTION
Primary: @pradeepnschrodinger 
Jira: https://schrodinger.atlassian.net/browse/LDTOOLS-255

Summary: Selecting a custom column in Sequence Viewer was resetting the `scrollLeft` of `rheaders` to 0. To preserve the scroll when selecting a custom column, set the element scroll after it is mounted in the DOM. For this, we are using `defer`, which sets the `scrollLeft` of `rheaders` after the current call stack is cleared. This ensures the element is fully mounted and rendered in the DOM (in the previous call stack) before adjusting the scroll position.

Demo:

https://github.com/user-attachments/assets/fc6d3747-a8c8-47a6-911d-1b4298003531


