### PR TITLE
  LDTOOLS-7: Sequence Viewer: Implement a way to highlight and differentiate non-natural residues in the sequence viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,8 +464,7 @@ zoomer: {
     maxResidueCodeLength: 6, // maximum length of residue code to be displayed in the viewer, codes with greater length are truncated with a fading effect 
     canvasEventScale: 1,
     residueFontPropsGetter: undefined // this can be overriden with a custom function of the following signature: (residueCode: string, pos: {x: number, y: number}) => { font: string, color: string}
-    residueTilePropsGetter: undefined // function to get the properties for a specific residue tile, which can be overriden with a custom function of the following signature: (pos: {x: number, y: number}) => { hasBottomBorder: boolean }
-
+    
     // overview box
     boxRectHeight: 2,
     boxRectWidth: 2,

--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ zoomer: {
     // canvas
     residueFont: "13px Helvetica Neue",
     residueFontOffset: [0, 0], // horizontal and vertical offset of residue font in px
+    maxResidueCodeLength: 6, // maximum length of residue code to be displayed in the viewer, codes with greater length are truncated with a fading effect 
     canvasEventScale: 1,
     residueFontPropsGetter: undefined // this can be overriden with a custom function of the following signature: (residueCode: string, pos: {x: number, y: number}) => { font: string, color: string}
     residueTilePropsGetter: undefined // function to get the properties for a specific residue tile, which can be overriden with a custom function of the following signature: (pos: {x: number, y: number}) => { hasBottomBorder: boolean }

--- a/README.md
+++ b/README.md
@@ -462,7 +462,8 @@ zoomer: {
     residueFont: "13px Helvetica Neue",
     residueFontOffset: [0, 0], // horizontal and vertical offset of residue font in px
     canvasEventScale: 1,
-    residueFontGetter: undefined // this can be overriden with a custom function of the following signature: (char: string, pos: {x: number, y: number}) => { font: string, color: string}
+    residueFontPropsGetter: undefined // this can be overriden with a custom function of the following signature: (residueCode: string, pos: {x: number, y: number}) => { font: string, color: string}
+    residueTilePropsGetter: undefined // function to get the properties for a specific residue tile, which can be overriden with a custom function of the following signature: (pos: {x: number, y: number}) => { hasBottomBorder: boolean }
 
     // overview box
     boxRectHeight: 2,

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ zoomer: {
     residueFontOffset: [0, 0], // horizontal and vertical offset of residue font in px
     maxResidueCodeLength: 6, // maximum length of residue code to be displayed in the viewer, codes with greater length are truncated with a fading effect 
     canvasEventScale: 1,
-    residueFontPropsGetter: undefined // this can be overriden with a custom function of the following signature: (residueCode: string, pos: {x: number, y: number}) => { font: string, color: string}
+    residueFontGetter: undefined // this can be overriden with a custom function of the following signature: (residueCode: string, pos: {x: number, y: number}) => { font: string, color: string}
     
     // overview box
     boxRectHeight: 2,

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ zoomer: {
     maxResidueCodeLength: 6, // maximum length of residue code to be displayed in the viewer, codes with greater length are truncated with a fading effect 
     canvasEventScale: 1,
     residueFontGetter: undefined // this can be overriden with a custom function of the following signature: (residueCode: string, pos: {x: number, y: number}) => { font: string, color: string}
-    
+
     // overview box
     boxRectHeight: 2,
     boxRectWidth: 2,

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -64,7 +64,7 @@ module.exports = Zoomer = Model.extend({
     maxResidueCodeLength: 6,
     canvasEventScale: 1,
     minLetterDrawSize: 11,
-    residueFontPropsGetter: undefined, // function to get the font properties for a specific residue
+    residueFontGetter: undefined, // function to get the font properties for a specific residue
 
     // overview box
     boxRectHeight: 2,

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -61,6 +61,7 @@ module.exports = Zoomer = Model.extend({
     // canvas
     residueFont: "13px Helvetica Neue",
     residueFontOffset: [0, 0], // horizontal and vertical offset of residue font in px
+    maxResidueCodeLength: 6,
     canvasEventScale: 1,
     minLetterDrawSize: 11,
     residueFontPropsGetter: undefined, // function to get the font properties for a specific residue

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -65,7 +65,6 @@ module.exports = Zoomer = Model.extend({
     canvasEventScale: 1,
     minLetterDrawSize: 11,
     residueFontPropsGetter: undefined, // function to get the font properties for a specific residue
-    residueTilePropsGetter: undefined, // function to get the properties for a specific residue tile
 
     // overview box
     boxRectHeight: 2,

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -14,6 +14,11 @@ module.exports = Zoomer = Model.extend({
     }), this
     );
 
+    this.listenTo( this, "change:columnWidth", () => {
+      // This recalculates the width of the alignment if the column width is changed
+      this._adjustWidth();
+    });
+
     this.listenTo(options.model, "reset add remove", () => {
       // This recalculates the width of the alignment if there is any row added or removed or reset
       this._adjustWidth();

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -58,7 +58,8 @@ module.exports = Zoomer = Model.extend({
     residueFontOffset: [0, 0], // horizontal and vertical offset of residue font in px
     canvasEventScale: 1,
     minLetterDrawSize: 11,
-    residueFontGetter: undefined, // function to get the font properties for a specific residue
+    residueFontPropsGetter: undefined, // function to get the font properties for a specific residue
+    residueTilePropsGetter: undefined, // function to get the properties for a specific residue tile
 
     // overview box
     boxRectHeight: 2,

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -73,7 +73,6 @@ class CanvasCharCache {
     const displayCode = code.slice(0, 6);
     const displayCodeWidth = this.ctx.measureText(displayCode).width;
     
-
     const startX = (width - displayCodeWidth) / 2;
     const startY = tileCenterY;
     this.ctx.fillText(displayCode.slice(0, 4), startX, startY);

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -61,30 +61,30 @@ class CanvasCharCache {
     const [xOffset, yOffset] = this.g.zoomer.get("residueFontOffset");
 
     this.ctx.textBaseline = 'middle';
-    
+    const maxResidueCodeLength = this.g.zoomer.get("maxResidueCodeLength")
     const tileCenterX = width / 2 + xOffset;
     const tileCenterY = height / 2 + yOffset;
-
-    if (code.length <= 6) {
+     code = 'xyzxyzx';
+    if (code.length <= maxResidueCodeLength) {
       this.ctx.textAlign = 'center';
       return this.ctx.fillText(code, tileCenterX, tileCenterY, width);
     }
     
-    const displayCode = code.slice(0, 6);
+    const displayCode = code.slice(0, maxResidueCodeLength);
     const displayCodeWidth = this.ctx.measureText(displayCode).width;
     
     const startX = (width - displayCodeWidth) / 2;
     const startY = tileCenterY;
-    this.ctx.fillText(displayCode.slice(0, 4), startX, startY);
+    this.ctx.fillText(displayCode.slice(0, maxResidueCodeLength - 2), startX, startY);
     
     this.ctx.fillStyle = "#333333";
-    const offsetX1 = startX + this.ctx.measureText(displayCode.slice(0, 4)).width;
-    this.ctx.fillText(displayCode[4], offsetX1, startY);
+    const offsetX1 = startX + this.ctx.measureText(displayCode.slice(0, maxResidueCodeLength - 2)).width;
+    this.ctx.fillText(displayCode[maxResidueCodeLength - 2], offsetX1, startY);
 
     this.ctx.fillStyle = "#555555";
     this.ctx.font = `italic ${fontProps.font}`;
-    const offsetX2 = offsetX1 + this.ctx.measureText(displayCode[4]).width;
-    return this.ctx.fillText(displayCode[5], offsetX2, startY);
+    const offsetX2 = offsetX1 + this.ctx.measureText(displayCode[maxResidueCodeLength - 2]).width;
+    return this.ctx.fillText(displayCode[maxResidueCodeLength - 1], offsetX2, startY);
   }
 };
 export default CanvasCharCache;

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -77,11 +77,11 @@ class CanvasCharCache {
     const startY = tileCenterY;
     this.ctx.fillText(displayCode.slice(0, 4), startX, startY);
     
-    this.ctx.fillStyle = "#262626";
+    this.ctx.fillStyle = "#333333";
     const offsetX1 = startX + this.ctx.measureText(displayCode.slice(0, 4)).width;
     this.ctx.fillText(displayCode[4], offsetX1, startY);
 
-    this.ctx.fillStyle = "#454545";
+    this.ctx.fillStyle = "#555555";
     this.ctx.font = `italic ${fontProps.font}`;
     const offsetX2 = offsetX1 + this.ctx.measureText(displayCode[4]).width;
     return this.ctx.fillText(displayCode[5], offsetX2, startY);

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -31,11 +31,11 @@ class CanvasCharCache {
   }
 
   getFontProperties(code, x, y) {
-    const residueFontPropsGetter = this.g.zoomer.get("residueFontPropsGetter");
+    const residueFontGetter = this.g.zoomer.get("residueFontGetter");
     let font = this.g.zoomer.get("residueFont");
     let color = "black";
-    if (residueFontPropsGetter !== undefined) {
-      const fontProps = residueFontPropsGetter(code, {x, y});
+    if (residueFontGetter !== undefined) {
+      const fontProps = residueFontGetter(code, {x, y});
       font = get(fontProps, "font") || font;
       color = get(fontProps, "color") || color;
     }

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -64,7 +64,7 @@ class CanvasCharCache {
     const maxResidueCodeLength = this.g.zoomer.get("maxResidueCodeLength")
     const tileCenterX = width / 2 + xOffset;
     const tileCenterY = height / 2 + yOffset;
-     code = 'xyzxyzx';
+
     if (code.length <= maxResidueCodeLength) {
       this.ctx.textAlign = 'center';
       return this.ctx.fillText(code, tileCenterX, tileCenterY, width);

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -31,11 +31,11 @@ class CanvasCharCache {
   }
 
   getFontProperties(code, x, y) {
-    const residueFontGetter = this.g.zoomer.get("residueFontGetter");
+    const residueFontPropsGetter = this.g.zoomer.get("residueFontPropsGetter");
     let font = this.g.zoomer.get("residueFont");
     let color = "black";
-    if (residueFontGetter !== undefined) {
-      const fontProps = residueFontGetter(code, {x, y});
+    if (residueFontPropsGetter !== undefined) {
+      const fontProps = residueFontPropsGetter(code, {x, y});
       font = get(fontProps, "font") || font;
       color = get(fontProps, "color") || color;
     }

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -157,20 +157,7 @@ const Drawer = {
       // This is done to make the selected residues more prominent
       that.ctx.globalAlpha = data.isSelected? 1: (data.hasResidueSelection)? 0.65: 1;
       that.ctx.fillStyle = color;
-
       that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);
-      const residueTilePropsGetter = that.g.zoomer.get("residueTilePropsGetter");
-      let hasBottomBorder = false;
-      if (residueTilePropsGetter !== undefined) {
-        const tileProps = residueTilePropsGetter({x: data.x, y: data.y});
-        hasBottomBorder = _.get(tileProps, 'hasBottomBorder') || hasBottomBorder;
-      }
-      if (hasBottomBorder) {
-        // Add border at the bottom of a residue tile
-        const bottomBorderHeight = 0.1 * data.rectHeight;
-        that.ctx.fillStyle = "#888888";
-        that.ctx.fillRect(data.xPos,data.yPos + data.rectHeight - bottomBorderHeight,data.rectWidth, bottomBorderHeight);
-      }
       return that.ctx.globalAlpha = 1;
     }
   },

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -167,8 +167,9 @@ const Drawer = {
       }
       if (hasBottomBorder) {
         // Add border at the bottom of a residue tile
-        that.ctx.fillStyle = "#666666";
-        that.ctx.fillRect(data.xPos,data.yPos + data.rectHeight - (0.1 * data.rectHeight),data.rectWidth,0.1 * data.rectHeight);
+        const bottomBorderHeight = 0.1 * data.rectHeight;
+        that.ctx.fillStyle = "#888888";
+        that.ctx.fillRect(data.xPos,data.yPos + data.rectHeight - bottomBorderHeight,data.rectWidth, bottomBorderHeight);
       }
       return that.ctx.globalAlpha = 1;
     }

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -157,7 +157,19 @@ const Drawer = {
       // This is done to make the selected residues more prominent
       that.ctx.globalAlpha = data.isSelected? 1: (data.hasResidueSelection)? 0.65: 1;
       that.ctx.fillStyle = color;
+
       that.ctx.fillRect(data.xPos,data.yPos,data.rectWidth,data.rectHeight);
+      const residueTilePropsGetter = that.g.zoomer.get("residueTilePropsGetter");
+      let hasBottomBorder = false;
+      if (residueTilePropsGetter !== undefined) {
+        const tileProps = residueTilePropsGetter({x: data.x, y: data.y});
+        hasBottomBorder = _.get(tileProps, 'hasBottomBorder') || false;
+      }
+      if (hasBottomBorder) {
+        // Add border at the bottom of a residue tile
+        that.ctx.fillStyle = "#666666";
+        that.ctx.fillRect(data.xPos,data.yPos + data.rectHeight - (0.1 * data.rectHeight),data.rectWidth,0.1 * data.rectHeight);
+      }
       return that.ctx.globalAlpha = 1;
     }
   },

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -121,7 +121,6 @@ const Drawer = {
 
     for (let j = start; j <  seq.length; j++) {
       let c = seq[j];
-      c = c.toUpperCase();
 
       // call the custom function
       res.x = j;

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -163,7 +163,7 @@ const Drawer = {
       let hasBottomBorder = false;
       if (residueTilePropsGetter !== undefined) {
         const tileProps = residueTilePropsGetter({x: data.x, y: data.y});
-        hasBottomBorder = _.get(tileProps, 'hasBottomBorder') || false;
+        hasBottomBorder = _.get(tileProps, 'hasBottomBorder') || hasBottomBorder;
       }
       if (hasBottomBorder) {
         // Add border at the bottom of a residue tile


### PR DESCRIPTION
Jira: [LDTOOLS-7](https://schrodinger.atlassian.net/browse/LDTOOLS-7)
Primary: @pradeepnschrodinger @karry08 

Summary: To highlight non-natural monomers, we have added a new getter, `residueTilePropsGetter`, in `zoomer`, which obtains props to style residue tiles. We use this getter to add bottom borders to monomer tiles. Moreover, we have added a fading effect for residue codes of more than `maxResidueCodeLength`. For this, we have filled the text in residue tiles in parts to have different styling for each part. We have made use of the `measureText` canvas API to determine the horizontal offset of subsequent text parts based on the previously filled text.