### PR TITLE
LDTOOLS-380: Sequence Viewer: Tooltip stays while scrolling through sequences

### DIFF
--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -72,7 +72,10 @@ const View = boneView.extend({
       this.throttledDraw = throttle(this.throttledDraw, 30);
     }
 
-    this.scrollBody = new ScrollBody(this.g, this, this.draw);
+    this.scrollBody = new ScrollBody(this.g, this, () => {
+      this.draw();
+      this.g.trigger("residue:scroll");
+    });
 
     return this.manageEvents();
   },


### PR DESCRIPTION
JIRA Ticket: [LDTOOLS-380](https://schrodinger.atlassian.net/browse/LDTOOLS-380)
Primary Reviewer: @pradeepnschrodinger

Summary:  Added a new event in MSA (residue:scroll) that is triggered when we scroll the canvas. I've used the same in Sequence Viewer to close the tooltip.