### PR TITLE
LDTOOLS-497: Sequence Viewer: Ruler resets when we change/scroll sequence view

### DIFF
--- a/css/msa.css
+++ b/css/msa.css
@@ -105,7 +105,7 @@
   transform: rotateX(180deg);
   position: absolute;
   bottom: 0;
-  padding: 3px 0px 5px; /* Affects the marker height, which is used in the calculation for height of HeaderBlock.js */
+  padding: 14px 0px 5px; /* Affects the marker height, which is used in the calculation for height of HeaderBlock.js */
   box-sizing: border-box;
 }
 

--- a/css/msa.css
+++ b/css/msa.css
@@ -105,7 +105,9 @@
   transform: rotateX(180deg);
   position: absolute;
   bottom: 0;
-  padding: 14px 0px 5px; /* Affects the marker height, which is used in the calculation for height of HeaderBlock.js */
+  /* Affects the marker height, which is used in the calculation for height of HeaderBlock.js. 
+  Padding increased from 3px to 14px to create space over ruler for overlay scrollbars */
+  padding: 14px 0px 5px;
   box-sizing: border-box;
 }
 

--- a/src/views/header/HeaderBlock.js
+++ b/src/views/header/HeaderBlock.js
@@ -31,7 +31,7 @@ const View = boneView.extend({
     this.renderSubviews();
 
     this.el.style.height = (
-      11 + // Height of scrollbar
+      22 + // Height of scrollbar
       22 + // Height of marker
       this.g.zoomer.get('rowHeight') * this.g.pinnedFeatures.getCurrentHeight()
     ) + 'px';

--- a/src/views/header/HeaderBlock.js
+++ b/src/views/header/HeaderBlock.js
@@ -31,7 +31,7 @@ const View = boneView.extend({
     this.renderSubviews();
 
     this.el.style.height = (
-      22 + // Height of scrollbar
+      22 + // Height of scrollbar (11px for `always on` Scrollbar, additional 11px for overlay scrollbar)
       22 + // Height of marker
       this.g.zoomer.get('rowHeight') * this.g.pinnedFeatures.getCurrentHeight()
     ) + 'px';

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -97,7 +97,6 @@ const View = boneView.extend({
     this.el.className = "biojs_msa_rheader";
     //@el.style.height = @g.zoomer.get("markerHeight") + "px"
     this._setWidth();
-
     this._adjustScrollingLeft();
     return this;
   },

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -97,7 +97,11 @@ const View = boneView.extend({
     this.el.className = "biojs_msa_rheader";
     //@el.style.height = @g.zoomer.get("markerHeight") + "px"
     this._setWidth();
-    this._adjustScrollingLeft();
+
+    _.defer(() => {
+      this._adjustScrollingLeft();
+    });
+
     return this;
   },
 
@@ -114,6 +118,7 @@ const View = boneView.extend({
       var scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");
       this.blockEvents = true;
       this.getView('headers').el.scrollLeft = scrollLeft;
+
     }
   },
 

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -98,10 +98,7 @@ const View = boneView.extend({
     //@el.style.height = @g.zoomer.get("markerHeight") + "px"
     this._setWidth();
 
-    _.defer(() => {
-      this._adjustScrollingLeft();
-    });
-
+    this._adjustScrollingLeft();
     return this;
   },
 

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -118,7 +118,6 @@ const View = boneView.extend({
       var scrollLeft = this.g.zoomer.get("_alignmentScrollLeft");
       this.blockEvents = true;
       this.getView('headers').el.scrollLeft = scrollLeft;
-
     }
   },
 


### PR DESCRIPTION
Primary: @pradeepnschrodinger 

Summary: Adding extra padding for overlay scrollbar which gets activated during a selection is made in Residue Sync-up. So preventing it from interfering with subsequent clicks on the ruler.